### PR TITLE
Correct mapping of standalone sealed subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 ## unreleased
+
+- Change typescript type mapping using computed property names syntax
+- Fix mapping of kotlin objects to empty objects in typescript
+- Correct mapping of standalone sealed subclasses in typescript, remove discriminator key
+
 ## v0.10.2
 
 - Replace lodash uniqueId with uuid v4

--- a/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/E2ETest.kt
+++ b/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/E2ETest.kt
@@ -82,6 +82,11 @@ class E2ETest {
         return Test("Erik", listOf(), mapOf(), 30)
     }
 
+    @ReactNativeMethod
+    fun testSealedClassProperties(test: TestSealedClassProperties): TestSealedClassProperties {
+        return test
+    }
+
 
     @ReactNativeMethod
     fun testKotlinDateTime(instant: Instant, date: @JSType("date") Instant, localDateTime: LocalDateTime, test: DateTimeTest, dateOrNull: @JSType("date") Instant?): Duration {
@@ -180,6 +185,13 @@ data class Test(
         val age: Int
     )
 }
+
+@Serializable
+data class TestSealedClassProperties(
+    val sealed: TestSealedType,
+    val sealedSubclassStandalone: TestSealedType.Option1,
+    val sealedSubclassStandaloneObject: TestSealedType.Option3,
+)
 
 @Serializable
 sealed class TestSealedType {

--- a/example/src/generated/models.ts
+++ b/example/src/generated/models.ts
@@ -28,12 +28,16 @@ export namespace com {
        */
       export function fromJsonTestSealedType(json: any): TestSealedType {
         const type = json['type'];
-        switch (type) {
+        return {
+          ...(() => {
+            switch (type) {
               case com.myrnproject.shared.TestSealedTypeType.Option1: return com.myrnproject.shared.TestSealedType.fromJsonOption1(json);
               case com.myrnproject.shared.TestSealedTypeType.Option2: return com.myrnproject.shared.TestSealedType.fromJsonOption2(json);
               case com.myrnproject.shared.TestSealedTypeType.Option3: return com.myrnproject.shared.TestSealedType.fromJsonOption3(json);
               default: throw new Error('Unknown discriminator value: ' + type);
-            };
+            }})(),
+          ['type']: type
+        };
       }
 
       /**
@@ -41,12 +45,16 @@ export namespace com {
        */
       export function toJsonTestSealedType(value: TestSealedType): any {
         const type = value['type'];
-        switch (type) {
+        return {
+          ...(() => {
+            switch (type) {
               case com.myrnproject.shared.TestSealedTypeType.Option1: return com.myrnproject.shared.TestSealedType.toJsonOption1(value);
               case com.myrnproject.shared.TestSealedTypeType.Option2: return com.myrnproject.shared.TestSealedType.toJsonOption2(value);
               case com.myrnproject.shared.TestSealedTypeType.Option3: return com.myrnproject.shared.TestSealedType.toJsonOption3(value);
               default: throw new Error('Unknown discriminator value: ' + type);
-            };
+            }})(),
+          ['type']: type
+        };
       }
 
       /**
@@ -94,18 +102,18 @@ export namespace com {
        */
       export function fromJsonTest(json: any): Test {
         return {
-          name: ((() => {
+          ['name']: ((() => {
             const temp = json['name'];
             return temp;
           })()) as string,
-          list: ((() => {
+          ['list']: ((() => {
             const temp = json['list'];
             return temp.map((it: any) => ((() => {
               const temp_ = it;
               return com.myrnproject.shared.Test.fromJsonNested(temp_);
             })()) as com.myrnproject.shared.Test.Nested);
           })()) as Array<com.myrnproject.shared.Test.Nested>,
-          map: ((() => {
+          ['map']: ((() => {
             const temp = json['map'];
             return Object.fromEntries(Object.entries(temp).map(([key, value]: [any, any]) => [((() => {
               const temp_ = key;
@@ -115,11 +123,11 @@ export namespace com {
               return com.myrnproject.shared.Test.fromJsonNested(temp_);
             })()) as com.myrnproject.shared.Test.Nested]));
           })()) as Record<string, com.myrnproject.shared.Test.Nested>,
-          long: ((() => {
+          ['long']: ((() => {
             const temp = json['long'];
             return temp;
           })()) as number,
-          bar: ((() => {
+          ['bar']: ((() => {
             const temp = json['bar'];
             return temp;
           })()) as number
@@ -131,18 +139,18 @@ export namespace com {
        */
       export function toJsonTest(value: Test): any {
         return {
-          name: (() => {
+          ['name']: (() => {
             const temp = value['name'];
             return temp;
           })(),
-          list: (() => {
+          ['list']: (() => {
             const temp = value['list'];
             return temp.map((it: any) => (() => {
               const temp_ = it;
               return com.myrnproject.shared.Test.toJsonNested(temp_);
             })());
           })(),
-          map: (() => {
+          ['map']: (() => {
             const temp = value['map'];
             return Object.fromEntries(Object.entries(temp).map(([key, value_]: [any, any]) => [(() => {
               const temp_ = key;
@@ -152,13 +160,66 @@ export namespace com {
               return com.myrnproject.shared.Test.toJsonNested(temp_);
             })()]));
           })(),
-          long: (() => {
+          ['long']: (() => {
             const temp = value['long'];
             return temp;
           })(),
-          bar: (() => {
+          ['bar']: (() => {
             const temp = value['bar'];
             return temp;
+          })()
+        };
+      }
+
+      /**
+       * Data class generated from {@link com.myrnproject.shared.TestSealedClassProperties}
+       */
+      export interface TestSealedClassProperties {
+
+        sealed: TestSealedType;
+
+        sealedSubclassStandalone: Omit<TestSealedType.Option1, 'type'>;
+
+        sealedSubclassStandaloneObject: Omit<TestSealedType.Option3, 'type'>;
+
+      }
+
+      /**
+       * Mapping generated from {@link com.myrnproject.shared.TestSealedClassProperties}
+       */
+      export function fromJsonTestSealedClassProperties(json: any): TestSealedClassProperties {
+        return {
+          ['sealed']: ((() => {
+            const temp = json['sealed'];
+            return com.myrnproject.shared.fromJsonTestSealedType(temp);
+          })()) as com.myrnproject.shared.TestSealedType,
+          ['sealedSubclassStandalone']: ((() => {
+            const temp = json['sealedSubclassStandalone'];
+            return com.myrnproject.shared.TestSealedType.fromJsonOption1(temp);
+          })()) as Omit<com.myrnproject.shared.TestSealedType.Option1, 'type'>,
+          ['sealedSubclassStandaloneObject']: ((() => {
+            const temp = json['sealedSubclassStandaloneObject'];
+            return com.myrnproject.shared.TestSealedType.fromJsonOption3(temp);
+          })()) as Omit<com.myrnproject.shared.TestSealedType.Option3, 'type'>
+        };
+      }
+
+      /**
+       * Mapping generated from {@link com.myrnproject.shared.TestSealedClassProperties}
+       */
+      export function toJsonTestSealedClassProperties(value: TestSealedClassProperties): any {
+        return {
+          ['sealed']: (() => {
+            const temp = value['sealed'];
+            return com.myrnproject.shared.toJsonTestSealedType(temp);
+          })(),
+          ['sealedSubclassStandalone']: (() => {
+            const temp = value['sealedSubclassStandalone'];
+            return com.myrnproject.shared.TestSealedType.toJsonOption1(temp);
+          })(),
+          ['sealedSubclassStandaloneObject']: (() => {
+            const temp = value['sealedSubclassStandaloneObject'];
+            return com.myrnproject.shared.TestSealedType.toJsonOption3(temp);
           })()
         };
       }
@@ -189,27 +250,27 @@ export namespace com {
        */
       export function fromJsonDateTimeTest(json: any): DateTimeTest {
         return {
-          instant: ((() => {
+          ['instant']: ((() => {
             const temp = json['instant'];
             return temp;
           })()) as string,
-          date: ((() => {
+          ['date']: ((() => {
             const temp = json['date'];
             return new Date(temp);
           })()) as Date,
-          dateAsString: ((() => {
+          ['dateAsString']: ((() => {
             const temp = json['dateAsString'];
             return temp;
           })()) as string,
-          localDateTime: ((() => {
+          ['localDateTime']: ((() => {
             const temp = json['localDateTime'];
             return temp;
           })()) as string,
-          duration: ((() => {
+          ['duration']: ((() => {
             const temp = json['duration'];
             return temp;
           })()) as string,
-          map: ((() => {
+          ['map']: ((() => {
             const temp = json['map'];
             return Object.fromEntries(Object.entries(temp).map(([key, value]: [any, any]) => [((() => {
               const temp_ = key;
@@ -219,7 +280,7 @@ export namespace com {
               return new Date(temp_);
             })()) as Date]));
           })()) as Record<string, Date>,
-          dateOrNull: ((() => {
+          ['dateOrNull']: ((() => {
             const temp = json['dateOrNull'];
             return temp === null ? null : (new Date(temp));
           })()) as Date | null
@@ -231,27 +292,27 @@ export namespace com {
        */
       export function toJsonDateTimeTest(value: DateTimeTest): any {
         return {
-          instant: (() => {
+          ['instant']: (() => {
             const temp = value['instant'];
             return temp;
           })(),
-          date: (() => {
+          ['date']: (() => {
             const temp = value['date'];
             return temp.toISOString();
           })(),
-          dateAsString: (() => {
+          ['dateAsString']: (() => {
             const temp = value['dateAsString'];
             return temp;
           })(),
-          localDateTime: (() => {
+          ['localDateTime']: (() => {
             const temp = value['localDateTime'];
             return temp;
           })(),
-          duration: (() => {
+          ['duration']: (() => {
             const temp = value['duration'];
             return temp;
           })(),
-          map: (() => {
+          ['map']: (() => {
             const temp = value['map'];
             return Object.fromEntries(Object.entries(temp).map(([key, value_]: [any, any]) => [(() => {
               const temp_ = key;
@@ -261,7 +322,7 @@ export namespace com {
               return temp_.toISOString();
             })()]));
           })(),
-          dateOrNull: (() => {
+          ['dateOrNull']: (() => {
             const temp = value['dateOrNull'];
             return temp === null ? null : (temp.toISOString());
           })()
@@ -315,12 +376,16 @@ export namespace com {
        */
       export function fromJsonTestSealedTypeWithCustomDiscriminator(json: any): TestSealedTypeWithCustomDiscriminator {
         const type = json['customType'];
-        switch (type) {
+        return {
+          ...(() => {
+            switch (type) {
               case com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option1: return com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.fromJsonOption1(json);
               case com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option2: return com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.fromJsonOption2(json);
               case com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option3: return com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.fromJsonOption3(json);
               default: throw new Error('Unknown discriminator value: ' + type);
-            };
+            }})(),
+          ['customType']: type
+        };
       }
 
       /**
@@ -328,12 +393,16 @@ export namespace com {
        */
       export function toJsonTestSealedTypeWithCustomDiscriminator(value: TestSealedTypeWithCustomDiscriminator): any {
         const type = value['customType'];
-        switch (type) {
+        return {
+          ...(() => {
+            switch (type) {
               case com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option1: return com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.toJsonOption1(value);
               case com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option2: return com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.toJsonOption2(value);
               case com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option3: return com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.toJsonOption3(value);
               default: throw new Error('Unknown discriminator value: ' + type);
-            };
+            }})(),
+          ['customType']: type
+        };
       }
 
       /**
@@ -345,15 +414,15 @@ export namespace com {
       /**
        * Mapping generated from {@link com.myrnproject.shared.FlowTest}
        */
-      export function fromJsonFlowTest(json: any): FlowTest {
-        return json;
+      export function fromJsonFlowTest(_: any): FlowTest {
+        return {};
       }
 
       /**
        * Mapping generated from {@link com.myrnproject.shared.FlowTest}
        */
-      export function toJsonFlowTest(value: FlowTest): any {
-        return value;
+      export function toJsonFlowTest(_: FlowTest): any {
+        return {};
       }
 
       /**
@@ -370,7 +439,7 @@ export namespace com {
        */
       export function fromJsonNonNested(json: any): NonNested {
         return {
-          bar: ((() => {
+          ['bar']: ((() => {
             const temp = json['bar'];
             return temp;
           })()) as string
@@ -382,7 +451,7 @@ export namespace com {
        */
       export function toJsonNonNested(value: NonNested): any {
         return {
-          bar: (() => {
+          ['bar']: (() => {
             const temp = value['bar'];
             return temp;
           })()
@@ -405,14 +474,13 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedType.Option1}
          */
-        export function fromJsonOption1(json: any): Option1 {
+        export function fromJsonOption1(json: any): Omit<Option1, 'type'> {
           return {
-            type: com.myrnproject.shared.TestSealedTypeType.Option1,
-            name: ((() => {
+            ['name']: ((() => {
               const temp = json['name'];
               return temp;
             })()) as string,
-            nested: ((() => {
+            ['nested']: ((() => {
               const temp = json['nested'];
               return com.myrnproject.shared.TestSealedType.Option1.fromJsonNested(temp);
             })()) as com.myrnproject.shared.TestSealedType.Option1.Nested
@@ -422,14 +490,13 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedType.Option1}
          */
-        export function toJsonOption1(value: Option1): any {
+        export function toJsonOption1(value: Omit<Option1, 'type'>): any {
           return {
-            type: com.myrnproject.shared.TestSealedTypeType.Option1,
-            name: (() => {
+            ['name']: (() => {
               const temp = value['name'];
               return temp;
             })(),
-            nested: (() => {
+            ['nested']: (() => {
               const temp = value['nested'];
               return com.myrnproject.shared.TestSealedType.Option1.toJsonNested(temp);
             })()
@@ -450,14 +517,13 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedType.Option2}
          */
-        export function fromJsonOption2(json: any): Option2 {
+        export function fromJsonOption2(json: any): Omit<Option2, 'type'> {
           return {
-            type: com.myrnproject.shared.TestSealedTypeType.Option2,
-            number: ((() => {
+            ['number']: ((() => {
               const temp = json['number'];
               return temp;
             })()) as number,
-            nonNested: ((() => {
+            ['nonNested']: ((() => {
               const temp = json['nonNested'];
               return com.myrnproject.shared.fromJsonNonNested(temp);
             })()) as com.myrnproject.shared.NonNested
@@ -467,14 +533,13 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedType.Option2}
          */
-        export function toJsonOption2(value: Option2): any {
+        export function toJsonOption2(value: Omit<Option2, 'type'>): any {
           return {
-            type: com.myrnproject.shared.TestSealedTypeType.Option2,
-            number: (() => {
+            ['number']: (() => {
               const temp = value['number'];
               return temp;
             })(),
-            nonNested: (() => {
+            ['nonNested']: (() => {
               const temp = value['nonNested'];
               return com.myrnproject.shared.toJsonNonNested(temp);
             })()
@@ -490,15 +555,15 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedType.Option3}
          */
-        export function fromJsonOption3(json: any): Option3 {
-          return json;
+        export function fromJsonOption3(_: any): Omit<Option3, 'type'> {
+          return {};
         }
 
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedType.Option3}
          */
-        export function toJsonOption3(value: Option3): any {
-          return value;
+        export function toJsonOption3(_: Omit<Option3, 'type'>): any {
+          return {};
         }
 
         export namespace Option1 {
@@ -517,7 +582,7 @@ export namespace com {
            */
           export function fromJsonNested(json: any): Nested {
             return {
-              nullable: ((() => {
+              ['nullable']: ((() => {
                 const temp = json['nullable'];
                 return temp === null ? null : (temp);
               })()) as string | null
@@ -529,7 +594,7 @@ export namespace com {
            */
           export function toJsonNested(value: Nested): any {
             return {
-              nullable: (() => {
+              ['nullable']: (() => {
                 const temp = value['nullable'];
                 return temp === null ? null : (temp);
               })()
@@ -556,14 +621,13 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.Option1}
          */
-        export function fromJsonOption1(json: any): Option1 {
+        export function fromJsonOption1(json: any): Omit<Option1, 'customType'> {
           return {
-            customType: com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option1,
-            name: ((() => {
+            ['name']: ((() => {
               const temp = json['name'];
               return temp;
             })()) as string,
-            nested: ((() => {
+            ['nested']: ((() => {
               const temp = json['nested'];
               return com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.Option1.fromJsonNested(temp);
             })()) as com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.Option1.Nested
@@ -573,14 +637,13 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.Option1}
          */
-        export function toJsonOption1(value: Option1): any {
+        export function toJsonOption1(value: Omit<Option1, 'customType'>): any {
           return {
-            customType: com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option1,
-            name: (() => {
+            ['name']: (() => {
               const temp = value['name'];
               return temp;
             })(),
-            nested: (() => {
+            ['nested']: (() => {
               const temp = value['nested'];
               return com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.Option1.toJsonNested(temp);
             })()
@@ -601,14 +664,13 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.Option2}
          */
-        export function fromJsonOption2(json: any): Option2 {
+        export function fromJsonOption2(json: any): Omit<Option2, 'customType'> {
           return {
-            customType: com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option2,
-            number: ((() => {
+            ['number']: ((() => {
               const temp = json['number'];
               return temp;
             })()) as number,
-            nonNested: ((() => {
+            ['nonNested']: ((() => {
               const temp = json['nonNested'];
               return com.myrnproject.shared.fromJsonNonNested(temp);
             })()) as com.myrnproject.shared.NonNested
@@ -618,14 +680,13 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.Option2}
          */
-        export function toJsonOption2(value: Option2): any {
+        export function toJsonOption2(value: Omit<Option2, 'customType'>): any {
           return {
-            customType: com.myrnproject.shared.TestSealedTypeWithCustomDiscriminatorType.Option2,
-            number: (() => {
+            ['number']: (() => {
               const temp = value['number'];
               return temp;
             })(),
-            nonNested: (() => {
+            ['nonNested']: (() => {
               const temp = value['nonNested'];
               return com.myrnproject.shared.toJsonNonNested(temp);
             })()
@@ -641,15 +702,15 @@ export namespace com {
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.Option3}
          */
-        export function fromJsonOption3(json: any): Option3 {
-          return json;
+        export function fromJsonOption3(_: any): Omit<Option3, 'customType'> {
+          return {};
         }
 
         /**
          * Mapping generated from {@link com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator.Option3}
          */
-        export function toJsonOption3(value: Option3): any {
-          return value;
+        export function toJsonOption3(_: Omit<Option3, 'customType'>): any {
+          return {};
         }
 
         export namespace Option1 {
@@ -668,7 +729,7 @@ export namespace com {
            */
           export function fromJsonNested(json: any): Nested {
             return {
-              nullable: ((() => {
+              ['nullable']: ((() => {
                 const temp = json['nullable'];
                 return temp === null ? null : (temp);
               })()) as string | null
@@ -680,7 +741,7 @@ export namespace com {
            */
           export function toJsonNested(value: Nested): any {
             return {
-              nullable: (() => {
+              ['nullable']: (() => {
                 const temp = value['nullable'];
                 return temp === null ? null : (temp);
               })()
@@ -709,11 +770,11 @@ export namespace com {
          */
         export function fromJsonNested(json: any): Nested {
           return {
-            name: ((() => {
+            ['name']: ((() => {
               const temp = json['name'];
               return temp;
             })()) as string,
-            age: ((() => {
+            ['age']: ((() => {
               const temp = json['age'];
               return temp;
             })()) as number
@@ -725,11 +786,11 @@ export namespace com {
          */
         export function toJsonNested(value: Nested): any {
           return {
-            name: (() => {
+            ['name']: (() => {
               const temp = value['name'];
               return temp;
             })(),
-            age: (() => {
+            ['age']: (() => {
               const temp = value['age'];
               return temp;
             })()

--- a/example/src/generated/modules.ts
+++ b/example/src/generated/modules.ts
@@ -77,6 +77,8 @@ interface NativeE2ETestInterface {
 
   example(input: string, testEnum: string): Promise<string>;
 
+  testSealedClassProperties(test: string): Promise<string>;
+
   testKotlinDateTime(
       instant: string,
       date: string,
@@ -175,6 +177,8 @@ export interface E2ETestInterface {
   example(input: com.myrnproject.shared.TestSealedType,
       testEnum: com.myrnproject.shared.Enum | null): Promise<com.myrnproject.shared.Test>;
 
+  testSealedClassProperties(test: com.myrnproject.shared.TestSealedClassProperties): Promise<com.myrnproject.shared.TestSealedClassProperties>;
+
   testKotlinDateTime(
       instant: string,
       date: Date,
@@ -187,7 +191,7 @@ export interface E2ETestInterface {
 
   testTypeAlias(test: com.myrnproject.shared.TestTypeAlias): Promise<com.myrnproject.shared.TestTypeAlias>;
 
-  testSealedSubtype(test: com.myrnproject.shared.TestSealedType.Option1): Promise<com.myrnproject.shared.TestSealedType.Option1>;
+  testSealedSubtype(test: Omit<com.myrnproject.shared.TestSealedType.Option1, 'type'>): Promise<Omit<com.myrnproject.shared.TestSealedType.Option1, 'type'>>;
 
   testSealedCustomDiscriminator(test: com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator): Promise<void>;
 
@@ -296,7 +300,7 @@ const NativeE2ETest = (NativeModules.E2ETest) as NativeE2ETestInterface;
 
 export const E2ETest: E2ETestInterface = {
   ...NativeE2ETest,
-  testDefaultTypes: (string: string, int: number, long: number, float: number, double: number, boolean: boolean, byte: number, char: number, short: number) =>
+  ['testDefaultTypes']: (string: string, int: number, long: number, float: number, double: number, boolean: boolean, byte: number, char: number, short: number) =>
       NativeE2ETest.testDefaultTypes((() => {
     const temp = string;
     return temp;
@@ -328,7 +332,7 @@ export const E2ETest: E2ETestInterface = {
     const temp = result;
     return temp;
   })()) as string),
-  testDefaultTypesNullable: (string: string | null, int: number | null, long: number | null, float: number | null, double: number | null, boolean: boolean | null, byte: number | null, char: number | null, short: number | null) =>
+  ['testDefaultTypesNullable']: (string: string | null, int: number | null, long: number | null, float: number | null, double: number | null, boolean: boolean | null, byte: number | null, char: number | null, short: number | null) =>
       NativeE2ETest.testDefaultTypesNullable((() => {
     const temp = string;
     return temp === null ? null : (temp);
@@ -360,7 +364,7 @@ export const E2ETest: E2ETestInterface = {
     const temp = result;
     return temp === null ? null : (temp);
   })()) as string | null),
-  testListAndMap: (list: Array<string>, map: Record<string, string>, nestedList: Array<Array<string>>, nestedMap: Record<string, Record<string, string>>, complexList: Array<com.myrnproject.shared.Test>, complexMap: Record<string, com.myrnproject.shared.Test>) =>
+  ['testListAndMap']: (list: Array<string>, map: Record<string, string>, nestedList: Array<Array<string>>, nestedMap: Record<string, Record<string, string>>, complexList: Array<com.myrnproject.shared.Test>, complexMap: Record<string, com.myrnproject.shared.Test>) =>
       NativeE2ETest.testListAndMap(JSON.stringify((() => {
     const temp = list;
     return temp.map((it: any) => (() => {
@@ -422,7 +426,7 @@ export const E2ETest: E2ETestInterface = {
       return temp_;
     })()) as number);
   })()) as Array<number>),
-  testListAndMapNullable: (list: Array<string> | null, map: Record<string, string> | null, nestedList: Array<Array<string>> | null, nestedMap: Record<string, Record<string, string>> | null, complexList: Array<com.myrnproject.shared.Test> | null, complexMap: Record<string, com.myrnproject.shared.Test> | null, listNullable: Array<string | null>, mapNullable: Record<string, string | null>, nestedListNullable: Array<Array<string | null> | null>, nestedMapNullable: Record<string, Record<string, string | null> | null>, complexListNullable: Array<com.myrnproject.shared.Test | null>, complexMapNullable: Record<string, com.myrnproject.shared.Test | null>) =>
+  ['testListAndMapNullable']: (list: Array<string> | null, map: Record<string, string> | null, nestedList: Array<Array<string>> | null, nestedMap: Record<string, Record<string, string>> | null, complexList: Array<com.myrnproject.shared.Test> | null, complexMap: Record<string, com.myrnproject.shared.Test> | null, listNullable: Array<string | null>, mapNullable: Record<string, string | null>, nestedListNullable: Array<Array<string | null> | null>, nestedMapNullable: Record<string, Record<string, string | null> | null>, complexListNullable: Array<com.myrnproject.shared.Test | null>, complexMapNullable: Record<string, com.myrnproject.shared.Test | null>) =>
       NativeE2ETest.testListAndMapNullable(JSON.stringify((() => {
     const temp = list;
     return temp === null ? null : (temp.map((it: any) => (() => {
@@ -538,7 +542,7 @@ export const E2ETest: E2ETestInterface = {
       return temp_ === null ? null : (temp_);
     })()) as number | null);
   })()) as Array<number | null>),
-  example: (input: com.myrnproject.shared.TestSealedType, testEnum: com.myrnproject.shared.Enum | null) =>
+  ['example']: (input: com.myrnproject.shared.TestSealedType, testEnum: com.myrnproject.shared.Enum | null) =>
       NativeE2ETest.example(JSON.stringify((() => {
     const temp = input;
     return com.myrnproject.shared.toJsonTestSealedType(temp);
@@ -549,7 +553,15 @@ export const E2ETest: E2ETestInterface = {
     const temp = result;
     return com.myrnproject.shared.fromJsonTest(temp);
   })()) as com.myrnproject.shared.Test),
-  testKotlinDateTime: (instant: string, date: Date, localDateTime: string, test: com.myrnproject.shared.DateTimeTest, dateOrNull: Date | null) =>
+  ['testSealedClassProperties']: (test: com.myrnproject.shared.TestSealedClassProperties) =>
+      NativeE2ETest.testSealedClassProperties(JSON.stringify((() => {
+    const temp = test;
+    return com.myrnproject.shared.toJsonTestSealedClassProperties(temp);
+  })())).then(JSON.parse).then((result) => ((() => {
+    const temp = result;
+    return com.myrnproject.shared.fromJsonTestSealedClassProperties(temp);
+  })()) as com.myrnproject.shared.TestSealedClassProperties),
+  ['testKotlinDateTime']: (instant: string, date: Date, localDateTime: string, test: com.myrnproject.shared.DateTimeTest, dateOrNull: Date | null) =>
       NativeE2ETest.testKotlinDateTime(JSON.stringify((() => {
     const temp = instant;
     return temp;
@@ -569,26 +581,26 @@ export const E2ETest: E2ETestInterface = {
     const temp = result;
     return temp;
   })()) as string),
-  getDateTimeTest: () => NativeE2ETest.getDateTimeTest().then(JSON.parse).then((result) => ((() => {
+  ['getDateTimeTest']: () => NativeE2ETest.getDateTimeTest().then(JSON.parse).then((result) => ((() => {
     const temp = result;
     return com.myrnproject.shared.fromJsonDateTimeTest(temp);
   })()) as com.myrnproject.shared.DateTimeTest),
-  testTypeAlias: (test: com.myrnproject.shared.TestTypeAlias) => NativeE2ETest.testTypeAlias(JSON.stringify((() => {
+  ['testTypeAlias']: (test: com.myrnproject.shared.TestTypeAlias) => NativeE2ETest.testTypeAlias(JSON.stringify((() => {
     const temp = test;
     return temp;
   })())).then(JSON.parse).then((result) => ((() => {
     const temp = result;
     return temp;
   })()) as com.myrnproject.shared.TestTypeAlias),
-  testSealedSubtype: (test: com.myrnproject.shared.TestSealedType.Option1) =>
+  ['testSealedSubtype']: (test: Omit<com.myrnproject.shared.TestSealedType.Option1, 'type'>) =>
       NativeE2ETest.testSealedSubtype(JSON.stringify((() => {
     const temp = test;
     return com.myrnproject.shared.TestSealedType.toJsonOption1(temp);
   })())).then(JSON.parse).then((result) => ((() => {
     const temp = result;
     return com.myrnproject.shared.TestSealedType.fromJsonOption1(temp);
-  })()) as com.myrnproject.shared.TestSealedType.Option1),
-  testSealedCustomDiscriminator: (test: com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator) =>
+  })()) as Omit<com.myrnproject.shared.TestSealedType.Option1, 'type'>),
+  ['testSealedCustomDiscriminator']: (test: com.myrnproject.shared.TestSealedTypeWithCustomDiscriminator) =>
       NativeE2ETest.testSealedCustomDiscriminator(JSON.stringify((() => {
     const temp = test;
     return com.myrnproject.shared.toJsonTestSealedTypeWithCustomDiscriminator(temp);
@@ -596,7 +608,7 @@ export const E2ETest: E2ETestInterface = {
     const temp = result;
     return temp;
   })()) as void),
-  testMapWithEnumKey: (map: Record<com.myrnproject.shared.Enum, string>) =>
+  ['testMapWithEnumKey']: (map: Record<com.myrnproject.shared.Enum, string>) =>
       NativeE2ETest.testMapWithEnumKey(JSON.stringify((() => {
     const temp = map;
     return Object.fromEntries(Object.entries(temp).map(([key, value]: [any, any]) => [(() => {
@@ -616,18 +628,18 @@ export const E2ETest: E2ETestInterface = {
       return temp_;
     })()) as string]));
   })()) as Record<com.myrnproject.shared.Enum, string>),
-  testFlow: (subscriptionId: string, currentValue: string | null) =>
+  ['testFlow']: (subscriptionId: string, currentValue: string | null) =>
       NativeE2ETest.testFlow(subscriptionId, currentValue),
-  testFlowNullable: (subscriptionId: string, currentValue: string | null) =>
+  ['testFlowNullable']: (subscriptionId: string, currentValue: string | null) =>
       NativeE2ETest.testFlowNullable(subscriptionId, currentValue),
-  testFlowComplex: (subscriptionId: string, currentValue: string | null) =>
+  ['testFlowComplex']: (subscriptionId: string, currentValue: string | null) =>
       NativeE2ETest.testFlowComplex(subscriptionId, currentValue),
-  testFlowParameterized: (subscriptionId: string, currentValue: string | null, arg1: number) =>
+  ['testFlowParameterized']: (subscriptionId: string, currentValue: string | null, arg1: number) =>
       NativeE2ETest.testFlowParameterized(subscriptionId, currentValue, (() => {
     const temp = arg1;
     return temp;
   })()),
-  testFlowParameterized2: (subscriptionId: string, currentValue: string | null, arg1: number, arg2: string) =>
+  ['testFlowParameterized2']: (subscriptionId: string, currentValue: string | null, arg1: number, arg2: string) =>
       NativeE2ETest.testFlowParameterized2(subscriptionId, currentValue, (() => {
     const temp = arg1;
     return temp;
@@ -635,12 +647,12 @@ export const E2ETest: E2ETestInterface = {
     const temp = arg2;
     return temp;
   })()),
-  testFlowParameterizedComplex: (subscriptionId: string, currentValue: string | null, arg1: com.myrnproject.shared.Test) =>
+  ['testFlowParameterizedComplex']: (subscriptionId: string, currentValue: string | null, arg1: com.myrnproject.shared.Test) =>
       NativeE2ETest.testFlowParameterizedComplex(subscriptionId, currentValue, JSON.stringify((() => {
     const temp = arg1;
     return com.myrnproject.shared.toJsonTest(temp);
   })())),
-  testFlowParameterizedComplex2: (subscriptionId: string, currentValue: string | null, arg1: Array<com.myrnproject.shared.Test>, arg2: Record<string, com.myrnproject.shared.Test>) =>
+  ['testFlowParameterizedComplex2']: (subscriptionId: string, currentValue: string | null, arg1: Array<com.myrnproject.shared.Test>, arg2: Record<string, com.myrnproject.shared.Test>) =>
       NativeE2ETest.testFlowParameterizedComplex2(subscriptionId, currentValue, JSON.stringify((() => {
     const temp = arg1;
     return temp.map((it: any) => (() => {
@@ -657,7 +669,7 @@ export const E2ETest: E2ETestInterface = {
       return com.myrnproject.shared.toJsonTest(temp_);
     })()]));
   })())),
-  testFlowParameterizedMany: (subscriptionId: string, currentValue: string | null, arg1: number, arg2: string, arg3: Array<string>, arg4: Record<string, com.myrnproject.shared.Test>) =>
+  ['testFlowParameterizedMany']: (subscriptionId: string, currentValue: string | null, arg1: number, arg2: string, arg3: Array<string>, arg4: Record<string, com.myrnproject.shared.Test>) =>
       NativeE2ETest.testFlowParameterizedMany(subscriptionId, currentValue, (() => {
     const temp = arg1;
     return temp;
@@ -680,11 +692,11 @@ export const E2ETest: E2ETestInterface = {
       return com.myrnproject.shared.toJsonTest(temp_);
     })()]));
   })())),
-  testFlowReturnInstant: (subscriptionId: string, currentValue: string | null) =>
+  ['testFlowReturnInstant']: (subscriptionId: string, currentValue: string | null) =>
       NativeE2ETest.testFlowReturnInstant(subscriptionId, currentValue),
-  testFlowReturnInstantAsDate: (subscriptionId: string, currentValue: string | null) =>
+  ['testFlowReturnInstantAsDate']: (subscriptionId: string, currentValue: string | null) =>
       NativeE2ETest.testFlowReturnInstantAsDate(subscriptionId, currentValue),
-  useTestFlow: () => {
+  ['useTestFlow']: () => {
     const value = useFlow(E2ETest.testFlow, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlow');
     return useMemo(() => (() => {
       const temp = value;
@@ -694,7 +706,7 @@ export const E2ETest: E2ETestInterface = {
       })()) as number);
     })(), [value]);
   },
-  useTestFlowNullable: () => {
+  ['useTestFlowNullable']: () => {
     const value = useFlow(E2ETest.testFlowNullable, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlowNullable');
     return useMemo(() => (() => {
       const temp = value;
@@ -704,7 +716,7 @@ export const E2ETest: E2ETestInterface = {
       })()) as number | null);
     })(), [value]);
   },
-  useTestFlowComplex: () => {
+  ['useTestFlowComplex']: () => {
     const value = useFlow(E2ETest.testFlowComplex, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlowComplex');
     return useMemo(() => (() => {
       const temp = value;
@@ -714,7 +726,7 @@ export const E2ETest: E2ETestInterface = {
       })()) as com.myrnproject.shared.Test);
     })(), [value]);
   },
-  useTestFlowParameterized: (arg1: number) => {
+  ['useTestFlowParameterized']: (arg1: number) => {
     const value = useFlow(E2ETest.testFlowParameterized, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlowParameterized', arg1);
     return useMemo(() => (() => {
       const temp = value;
@@ -724,7 +736,7 @@ export const E2ETest: E2ETestInterface = {
       })()) as com.myrnproject.shared.FlowTest);
     })(), [value]);
   },
-  useTestFlowParameterized2: (arg1_: number, arg2: string) => {
+  ['useTestFlowParameterized2']: (arg1_: number, arg2: string) => {
     const value = useFlow(E2ETest.testFlowParameterized2, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlowParameterized2', arg1_, arg2);
     return useMemo(() => (() => {
       const temp = value;
@@ -734,7 +746,7 @@ export const E2ETest: E2ETestInterface = {
       })()) as com.myrnproject.shared.FlowTest);
     })(), [value]);
   },
-  useTestFlowParameterizedComplex: (arg1__: com.myrnproject.shared.Test) => {
+  ['useTestFlowParameterizedComplex']: (arg1__: com.myrnproject.shared.Test) => {
     const value = useFlow(E2ETest.testFlowParameterizedComplex, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlowParameterizedComplex', arg1__);
     return useMemo(() => (() => {
       const temp = value;
@@ -744,7 +756,7 @@ export const E2ETest: E2ETestInterface = {
       })()) as com.myrnproject.shared.FlowTest);
     })(), [value]);
   },
-  useTestFlowParameterizedComplex2: (arg1___: Array<com.myrnproject.shared.Test>, arg2_: Record<string, com.myrnproject.shared.Test>) =>
+  ['useTestFlowParameterizedComplex2']: (arg1___: Array<com.myrnproject.shared.Test>, arg2_: Record<string, com.myrnproject.shared.Test>) =>
       {
     const value = useFlow(E2ETest.testFlowParameterizedComplex2, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlowParameterizedComplex2', arg1___, arg2_);
     return useMemo(() => (() => {
@@ -755,7 +767,7 @@ export const E2ETest: E2ETestInterface = {
       })()) as com.myrnproject.shared.FlowTest);
     })(), [value]);
   },
-  useTestFlowParameterizedMany: (arg1____: number, arg2__: string, arg3: Array<string>, arg4: Record<string, com.myrnproject.shared.Test>) =>
+  ['useTestFlowParameterizedMany']: (arg1____: number, arg2__: string, arg3: Array<string>, arg4: Record<string, com.myrnproject.shared.Test>) =>
       {
     const value = useFlow(E2ETest.testFlowParameterizedMany, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlowParameterizedMany', arg1____, arg2__, arg3, arg4);
     return useMemo(() => (() => {
@@ -766,7 +778,7 @@ export const E2ETest: E2ETestInterface = {
       })()) as com.myrnproject.shared.FlowTest);
     })(), [value]);
   },
-  useTestFlowReturnInstant: () => {
+  ['useTestFlowReturnInstant']: () => {
     const value = useFlow(E2ETest.testFlowReturnInstant, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlowReturnInstant');
     return useMemo(() => (() => {
       const temp = value;
@@ -776,7 +788,7 @@ export const E2ETest: E2ETestInterface = {
       })()) as string);
     })(), [value]);
   },
-  useTestFlowReturnInstantAsDate: () => {
+  ['useTestFlowReturnInstantAsDate']: () => {
     const value = useFlow(E2ETest.testFlowReturnInstantAsDate, NativeE2ETest.unsubscribeFromToolkitUseFlow, 'E2ETest.testFlowReturnInstantAsDate');
     return useMemo(() => (() => {
       const temp = value;
@@ -792,20 +804,20 @@ const NativeNameManager = (NativeModules.NameManager) as NativeNameManagerInterf
 
 export const NameManager: NameManagerInterface = {
   ...NativeNameManager,
-  setName: (name: string) => NativeNameManager.setName((() => {
+  ['setName']: (name: string) => NativeNameManager.setName((() => {
     const temp = name;
     return temp;
   })()).then((result) => ((() => {
     const temp = result;
     return temp;
   })()) as void),
-  getName: () => NativeNameManager.getName().then((result) => ((() => {
+  ['getName']: () => NativeNameManager.getName().then((result) => ((() => {
     const temp = result;
     return temp === null ? null : (temp);
   })()) as string | null),
-  name: (subscriptionId: string, currentValue: string | null) =>
+  ['name']: (subscriptionId: string, currentValue: string | null) =>
       NativeNameManager.name(subscriptionId, currentValue),
-  useName: () => {
+  ['useName']: () => {
     const value = useFlow(NameManager.name, NativeNameManager.unsubscribeFromToolkitUseFlow, 'NameManager.name');
     return useMemo(() => (() => {
       const temp = value;
@@ -821,7 +833,7 @@ const NativeNotificationDemo = (NativeModules.NotificationDemo) as NativeNotific
 
 export const NotificationDemo: NotificationDemoInterface = {
   ...NativeNotificationDemo,
-  addEventListener: (key: string, listener: (result: any) => void) => {
+  ['addEventListener']: (key: string, listener: (result: any) => void) => {
     const eventEmitter = new NativeEventEmitter((NativeNotificationDemo) as any);
     return eventEmitter.addListener(key, listener);
   }
@@ -831,16 +843,16 @@ const NativeTimeProvider = (NativeModules.TimeProvider) as NativeTimeProviderInt
 
 export const TimeProvider: TimeProviderInterface = {
   ...NativeTimeProvider,
-  time: (subscriptionId: string, currentValue: string | null) =>
+  ['time']: (subscriptionId: string, currentValue: string | null) =>
       NativeTimeProvider.time(subscriptionId, currentValue),
-  isAfter: (subscriptionId: string, currentValue: string | null, time: string) =>
+  ['isAfter']: (subscriptionId: string, currentValue: string | null, time: string) =>
       NativeTimeProvider.isAfter(subscriptionId, currentValue, (() => {
     const temp = time;
     return temp;
   })()),
-  timeAsState: (subscriptionId: string, currentValue: string | null) =>
+  ['timeAsState']: (subscriptionId: string, currentValue: string | null) =>
       NativeTimeProvider.timeAsState(subscriptionId, currentValue),
-  useTime: () => {
+  ['useTime']: () => {
     const value = useFlow(TimeProvider.time, NativeTimeProvider.unsubscribeFromToolkitUseFlow, 'TimeProvider.time');
     return useMemo(() => (() => {
       const temp = value;
@@ -850,7 +862,7 @@ export const TimeProvider: TimeProviderInterface = {
       })()) as Date);
     })(), [value]);
   },
-  useIsAfter: (time: string) => {
+  ['useIsAfter']: (time: string) => {
     const value = useFlow(TimeProvider.isAfter, NativeTimeProvider.unsubscribeFromToolkitUseFlow, 'TimeProvider.isAfter', time);
     return useMemo(() => (() => {
       const temp = value;
@@ -860,7 +872,7 @@ export const TimeProvider: TimeProviderInterface = {
       })()) as boolean);
     })(), [value]);
   },
-  useTimeAsState: () => {
+  ['useTimeAsState']: () => {
     const value = useFlow(TimeProvider.timeAsState, NativeTimeProvider.unsubscribeFromToolkitUseFlow, 'TimeProvider.timeAsState');
     return useMemo(() => (() => {
       const temp = value;


### PR DESCRIPTION
- Change typescript type mapping using computed property names syntax
- Fix mapping of kotlin objects to empty objects in typescript
- Correct mapping of standalone sealed subclasses in typescript, remove discriminator key