### PR TITLE
Check for Unit in iOS promise util

### DIFF
--- a/kotlin/reakt-native-toolkit/src/iosMain/kotlin/de/voize/reaktnativetoolkit/util/PromiseUtil.kt
+++ b/kotlin/reakt-native-toolkit/src/iosMain/kotlin/de/voize/reaktnativetoolkit/util/PromiseUtil.kt
@@ -10,7 +10,12 @@ data class PromiseIOS(val resolve: IOSResolvePromise<Any?>, val reject: IOSRejec
 
 inline fun <reified T> PromiseIOS.runCatchingWithArguments(action: () -> T, argumentsTransform: (T) -> Any?) {
     kotlin
-        .runCatching { argumentsTransform(action()) }
+        .runCatching {
+            when (val result = action()) {
+                is Unit -> null
+                else -> argumentsTransform(result)
+            }
+        }
         .onSuccess(resolve)
         .onFailure {
             reject(it, it.getJSExtraData())


### PR DESCRIPTION
Check for `Unit` on the iOS `runCatchingWithArguments` to mirror the Android implementation.

Resolves https://github.com/voize-gmbh/reakt-native-toolkit/issues/54.