### PR TITLE
Change minSdk to 21

### DIFF
--- a/kotlin/reakt-native-toolkit/build.gradle.kts
+++ b/kotlin/reakt-native-toolkit/build.gradle.kts
@@ -11,7 +11,7 @@ android {
     compileSdk = 33
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 21
     }
 
     compileOptions {


### PR DESCRIPTION
Expo uses 21 by default, and nothing in the toolkit prevents us from using the same.