### PR TITLE
Update Kotlin to 2.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
 ## unreleased
+
+- Update Kotlin to 2.0.21
+- Update KSP to 2.0.21-1.0.25
+- Update KotlinPoet to 1.18.1
+- Return interface (RCTBridgeModuleProtocol, ReactNativeModuleBase) instead of narrow type in RN module provider getModule
+
 ## v0.18.0
 
 - Update example app iOS part to correct setup for RN 0.74.0

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 34
         targetSdkVersion = 34
         ndkVersion = "26.1.10909125"
-        kotlinVersion = "1.9.23"
+        kotlinVersion = "2.0.21"
     }
     repositories {
         google()

--- a/example/android/shared/MyAppShared.podspec
+++ b/example/android/shared/MyAppShared.podspec
@@ -22,6 +22,10 @@ Pod::Spec.new do |spec|
         Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
     end
                 
+    spec.xcconfig = {
+        'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO',
+    }
+                
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':shared',
         'PRODUCT_MODULE_NAME' => 'shared',

--- a/example/android/shared/build.gradle.kts
+++ b/example/android/shared/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
     kotlin("plugin.serialization")
     id("com.android.library")
     id("org.jetbrains.compose") version "1.6.10"
-    id("com.google.devtools.ksp") version "1.9.23-1.0.20"
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21"
+    id("com.google.devtools.ksp") version "2.0.21-1.0.25"
 }
 
 val reaktNativeToolkitVersion = "0.18.0"

--- a/kotlin/gradle/libs.versions.toml
+++ b/kotlin/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-kotlin = "1.9.23"
+kotlin = "2.0.21"
 kotlin-coroutines = "1.8.0"
-ksp = "1.9.23-1.0.20"
-kotlinpoet = "1.13.2"
+ksp = "2.0.21-1.0.25"
+kotlinpoet = "1.18.1"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/kotlin/kotlin-js-store/yarn.lock
+++ b/kotlin/kotlin-js-store/yarn.lock
@@ -7,7 +7,7 @@ format-util@^1.0.5:
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
   integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==

--- a/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeModuleGenerator.kt
+++ b/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeModuleGenerator.kt
@@ -372,7 +372,7 @@ class ReactNativeModuleGenerator(
                     addModifiers(KModifier.OVERRIDE)
                     addParameter(reactApplicationContextVarName, ReactApplicationContextClassName)
                     addParameter(lifecycleScopeVarName, CoroutineScopeClassName)
-                    returns(ClassName(packageName, androidModuleClassName))
+                    returns(ReactNativeModuleBaseClassName)
                     addStatement(
                         "return %T(%L)",
                         ClassName(packageName, androidModuleClassName),
@@ -432,7 +432,7 @@ class ReactNativeModuleGenerator(
                     val lifecycleScopeVarName = "lifecycleScope"
                     addModifiers(KModifier.OVERRIDE)
                     addParameter(lifecycleScopeVarName, CoroutineScopeClassName)
-                    returns(ClassName(packageName, iOSModuleClassName))
+                    returns(RCTBridgeModuleProtocolClassName)
                     addStatement(
                         "return %T(%L)",
                         ClassName(packageName, iOSModuleClassName),
@@ -644,7 +644,7 @@ class ReactNativeModuleGenerator(
                     .build()
             )
             superclass(ClassName("platform.darwin", "NSObject"))
-            addSuperinterface(RCTBrigdeModuleProtocolClassName)
+            addSuperinterface(RCTBridgeModuleProtocolClassName)
             addProperty(
                 PropertySpec.builder(coroutineScopeVarName, CoroutineScopeClassName)
                     .addModifiers(KModifier.PRIVATE).initializer(coroutineScopeVarName).build()
@@ -1349,18 +1349,20 @@ private val ReactApplicationContextClassName =
 private val CoroutineScopeClassName = ClassName("kotlinx.coroutines", "CoroutineScope")
 private val PromiseIOSClassName = ClassName(toolkitUtilPackageName, "PromiseIOS")
 private val EventEmitterIOS = ClassName(toolkitUtilPackageName, "EventEmitterIOS")
-private val ReactNativeModuleProviderClassName =
-    ClassName(toolkitUtilPackageName, "ReactNativeModuleProvider")
+
+private val ReactNativeModuleProviderClassName = ClassName(toolkitUtilPackageName, "ReactNativeModuleProvider")
+private val ReactNativeModuleBaseClassName = ClassName(toolkitUtilPackageName, "ReactNativeModuleBase")
+
 private val RCTCallableJSModulesClassName =
     ClassName(reactNativeInteropNamespace, "RCTCallableJSModules")
-private val RCTBrigdeModuleProtocolClassName =
+private val RCTBridgeModuleProtocolClassName =
     ClassName(reactNativeInteropNamespace, "RCTBridgeModuleProtocol")
 private val ListOfMember = MemberName("kotlin.collections", "listOf")
 private val JsonClassName = ClassName("kotlinx.serialization.json", "Json")
 private val EncodeToStringMember = MemberName("kotlinx.serialization", "encodeToString")
 private val DecodeFromStringMember = MemberName("kotlinx.serialization", "decodeFromString")
-private val FlowToReactMember = MemberName("$toolkitPackageName.util", "toReact")
+private val FlowToReactMember = MemberName(toolkitUtilPackageName, "toReact")
 private val UnsubscribeFromFlowMember =
-    MemberName("$toolkitPackageName.util", "unsubscribeFromFlow")
+    MemberName(toolkitUtilPackageName, "unsubscribeFromFlow")
 private val RCTBridgeMethodWrapperClassName =
-    ClassName("$toolkitPackageName.util", "RCTBridgeMethodWrapper")
+    ClassName(toolkitUtilPackageName, "RCTBridgeMethodWrapper")


### PR DESCRIPTION
Currently using the Toolkit with Kotlin 2.0.21 creates errors like

on iOS
```
> Task :shared:compileKotlinIosArm64
e: file:///.../build/generated/ksp/iosArm64/iosArm64Main/kotlin/.../TestModuleRNModuleProvider.kt:9:23 'fun getModule(lifecycleScope: CoroutineScope): TestModuleRNModuleIOS' has no corresponding expected declaration
The following declaration is incompatible because return type is different:
    fun getModule(lifecycleScope: CoroutineScope): RCTBridgeModuleProtocol
```

on Android
```
> Task :shared:compileDebugKotlinAndroid FAILED
e: file:///.../build/generated/ksp/android/androidDebug/kotlin/.../TestModuleRNModuleProvider.kt:10:23 'fun getModule(reactApplicationContext: ReactApplicationContext, lifecycleScope: CoroutineScope): TestModuleRNModuleAndroid' has no corresponding expected declaration
The following declaration is incompatible because return type is different:
    fun getModule(reactApplicationContext: ReactApplicationContext, lifecycleScope: CoroutineScope): ReactNativeModuleBase
```

The provider platform implementation currently return the RNModule directly, the interface declares `ReactNativeModuleBase` on Android and `RCTBridgeModuleProtocol` on iOS. To fix this we drop the type narrowing in the implementation and return `ReactNativeModuleBase` and `RCTBridgeModuleProtocol` in the implementation, too.

Before

```kotlin
// build/generated/ksp/iosArm64/iosArm64Main/kotlin/.../TestModuleRNModuleProvider.kt

public actual class TestModuleRNModuleProvider actual constructor(...) : ReactNativeModuleProvider {
  override fun getModule(lifecycleScope: CoroutineScope): TestModuleRNModuleIOS =
      TestModuleRNModuleIOS(lifecycleScope, ...)
}
```

```kotlin
// /build/generated/ksp/android/androidDebug/kotlin/.../TestModuleRNModuleProvider.kt

public actual class TestModuleRNModuleProvider actual constructor() : ReactNativeModuleProvider {
  override fun getModule(reactApplicationContext: ReactApplicationContext,
      lifecycleScope: CoroutineScope): TestModuleRNModuleAndroid =
      E2ETestAndroid(reactApplicationContext, lifecycleScope)
}
```

After

```kotlin
// build/generated/ksp/iosArm64/iosArm64Main/kotlin/.../TestModuleRNModuleProvider.kt

public actual class TestModuleRNModuleProvider actual constructor(...) : ReactNativeModuleProvider {
  override fun getModule(lifecycleScope: CoroutineScope): RCTBridgeModuleProtocol =
      TestModuleRNModuleIOS(lifecycleScope, ...)
}
```

```kotlin
// /build/generated/ksp/android/androidDebug/kotlin/.../TestModuleRNModuleProvider.kt

public actual class TestModuleRNModuleProvider actual constructor() : ReactNativeModuleProvider {
  override fun getModule(reactApplicationContext: ReactApplicationContext,
      lifecycleScope: CoroutineScope): ReactNativeModuleBase =
      E2ETestAndroid(reactApplicationContext, lifecycleScope)
}
```