### PR TITLE
Fix Compose view managers for multiple instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update KSP to 2.0.21-1.0.25
 - Update KotlinPoet to 1.18.1
 - Return interface (RCTBridgeModuleProtocol, ReactNativeModuleBase) instead of narrow type in RN module provider getModule
+- Fix Compose view managers for multiple instances
 
 ## v0.18.0
 

--- a/README.md
+++ b/README.md
@@ -720,9 +720,9 @@ class MyRNPackage(private val analytics: Analytics) : ReactPackage {
 ```kotlin
 // iosMain
 
-import de.voize.reaktnativetoolkit.util.ReactNativeIOSViewManager
+import de.voize.reaktnativetoolkit.util.ReactNativeIOSViewWrapperFactory
 import de.voize.reaktnativetoolkit.util.getModules
-import de.voize.reaktnativetoolkit.util.getViewManagers
+import de.voize.reaktnativetoolkit.util.getViewWrapperFactories
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import react_native.RCTBridgeModuleProtocol
@@ -734,10 +734,10 @@ class IOSRNModules(private val analytics: Analytics) {
         // ...
     }
 
-    fun createViewManagers(): Map<String, ReactNativeIOSViewManager> {
+    fun createViewWrapperFactories(): Map<String, ReactNativeIOSViewWrapperFactory> {
         return getReactNativeViewManagerProviders(
             persistentConfig,
-        ).getViewManagers()
+        ).getViewWrapperFactories()
     }
 }
 ```
@@ -753,7 +753,7 @@ class IOSRNModules(private val analytics: Analytics) {
     {
         SharedIOSRNModules* iOSRNModules = [[SharedIOSRNModules alloc] init];
         NSArray<id<RCTBridgeModule>> *rnNativeModules = [iOSRNModules createNativeModules];
-        NSArray<id<RCTBridgeModule>> *rnViewManagers = [ReactNativeViewManagers getRNViewManagers:[iOSRNModules createViewManagers]];
+        NSArray<id<RCTBridgeModule>> *rnViewManagers = [ReactNativeViewManagers getRNViewManagers:[iOSRNModules createViewWrapperFactories]];
         return [rnNativeModules arrayByAddingObjectsFromArray:rnViewManagers];
     }
 }

--- a/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MySecondComposeView.kt
+++ b/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MySecondComposeView.kt
@@ -1,0 +1,25 @@
+package com.myrnproject.shared
+
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import de.voize.reaktnativetoolkit.annotation.ReactNativeProp
+import de.voize.reaktnativetoolkit.annotation.ReactNativeViewManager
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+@ReactNativeViewManager("MySecondComposeView")
+internal fun MySecondComposeView(
+    @ReactNativeProp
+    index: Flow<Int>,
+    @ReactNativeProp
+    onPress: () -> Unit,
+) {
+    val indexValue by index.collectAsState(null)
+
+    Button(onClick = onPress) {
+        Text("Compose View Index: $indexValue")
+    }
+}

--- a/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/RNViewManagersList.kt
+++ b/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/RNViewManagersList.kt
@@ -7,5 +7,6 @@ fun getReactNativeViewManagerProviders(
 ): List<ReactNativeViewManagerProvider> {
     return listOf(
         MyComposeViewRNViewManagerProvider(persistentConfig),
+        MySecondComposeViewRNViewManagerProvider(),
     )
 }

--- a/example/android/shared/src/iosMain/kotlin/com/myrnproject/shared/IOSRNModules.kt
+++ b/example/android/shared/src/iosMain/kotlin/com/myrnproject/shared/IOSRNModules.kt
@@ -1,8 +1,8 @@
 package com.myrnproject.shared
 
-import de.voize.reaktnativetoolkit.util.ReactNativeIOSViewManager
+import de.voize.reaktnativetoolkit.util.ReactNativeIOSViewWrapperFactory
 import de.voize.reaktnativetoolkit.util.getModules
-import de.voize.reaktnativetoolkit.util.getViewManagers
+import de.voize.reaktnativetoolkit.util.getViewWrapperFactories
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import react_native.RCTBridgeModuleProtocol
@@ -18,9 +18,9 @@ class IOSRNModules {
         ).getModules(coroutineScope)
     }
 
-    fun createViewManagers(): Map<String, ReactNativeIOSViewManager> {
+    fun createViewWrapperFactories(): Map<String, ReactNativeIOSViewWrapperFactory> {
         return getReactNativeViewManagerProviders(
             persistentConfig,
-        ).getViewManagers()
+        ).getViewWrapperFactories()
     }
 }

--- a/example/ios/MyRNProject/AppDelegate.mm
+++ b/example/ios/MyRNProject/AppDelegate.mm
@@ -16,7 +16,7 @@
 {
   SharedIOSRNModules* iOSRNModules = [[SharedIOSRNModules alloc] init];
   NSArray<id<RCTBridgeModule>> *rnNativeModules = [iOSRNModules createNativeModules];
-  NSArray<id<RCTBridgeModule>> *rnViewManagers = [ReactNativeViewManagers getRNViewManagers:[iOSRNModules createViewManagers]];
+  NSArray<id<RCTBridgeModule>> *rnViewManagers = [ReactNativeViewManagers getRNViewManagers:[iOSRNModules createViewWrapperFactories]];
   return [rnNativeModules arrayByAddingObjectsFromArray:rnViewManagers];
 }
 

--- a/example/src/components/NativeView.tsx
+++ b/example/src/components/NativeView.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { MyComposeView } from '../generated/nativeComponents';
+import {
+  MyComposeView,
+  MySecondComposeView,
+} from '../generated/nativeComponents';
 import { com } from '../generated/models';
 
 const NativeComposeView: React.FC = () => {
@@ -44,8 +47,18 @@ const NativeComposeView: React.FC = () => {
           }}
         />
       </View>
-      <Text>Counter: {counter}</Text>
-      <Text>Compose text input value: {text}</Text>
+      <View style={{ marginBottom: 20 }}>
+        <Text>Counter: {counter}</Text>
+        <Text>Compose text input value: {text}</Text>
+      </View>
+      {[1, 2, 3].map((_, i) => (
+        <MySecondComposeView
+          key={`item-${i}`}
+          index={i}
+          onPress={() => console.log('Pressed', i)}
+          style={styles.nativeListItem}
+        />
+      ))}
     </View>
   );
 };
@@ -67,10 +80,16 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: 'hsl(200, 10%, 50%)',
     width: '100%',
+    marginBottom: 12,
   },
   nativeView: {
     width: '100%',
     height: 400,
+  },
+  nativeListItem: {
+    width: '100%',
+    height: 30,
+    marginBottom: 8,
   },
 });
 

--- a/example/src/generated/nativeComponents.tsx
+++ b/example/src/generated/nativeComponents.tsx
@@ -64,6 +64,22 @@ interface MyComposeViewProps extends ViewProps {
 
 }
 
+interface NativeMySecondComposeViewProps {
+
+  index: number;
+
+  onPress: (event: any) => void;
+
+}
+
+interface MySecondComposeViewProps extends ViewProps {
+
+  index: number;
+
+  onPress: () => void;
+
+}
+
 const NativeMyComposeView = requireNativeComponent<NativeMyComposeViewProps>("MyComposeView");
 
 export const MyComposeView = (props: MyComposeViewProps) => {
@@ -178,4 +194,22 @@ export const MyComposeView = (props: MyComposeViewProps) => {
   onTextFieldValueChange={nativeOnTextFieldValueChange}
   onButtonPress={nativeOnButtonPress}
   onTestParams={nativeOnTestParams} />;
+};
+
+const NativeMySecondComposeView = requireNativeComponent<NativeMySecondComposeViewProps>("MySecondComposeView");
+
+export const MySecondComposeView = (props: MySecondComposeViewProps) => {
+  const {
+  index,
+  onPress,
+  ...rest
+  } = props;
+  const indexMemoized = useMemo(() => (() => {
+    const temp = index;
+    return temp;
+  })(), [index]);
+  const nativeOnPress = useCallback(() => {
+    onPress()}, [onPress]);
+  return <NativeMySecondComposeView {...rest} index={indexMemoized}
+  onPress={nativeOnPress} />;
 };

--- a/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeModuleGenerator.kt
+++ b/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeModuleGenerator.kt
@@ -1284,7 +1284,7 @@ internal fun KSValueParameter.toParameterSpec(): ParameterSpec {
             this.type.toTypeName()
         } catch (e: Throwable) {
             throw IllegalArgumentException("Could get type of $this at ${this.location}", e)
-        }
+        },
     ).build()
 }
 

--- a/kotlin/reakt-native-toolkit/src/iosMain/kotlin/de/voize/reaktnativetoolkit/util/ReactNativeIOSViewWrapper.kt
+++ b/kotlin/reakt-native-toolkit/src/iosMain/kotlin/de/voize/reaktnativetoolkit/util/ReactNativeIOSViewWrapper.kt
@@ -9,4 +9,11 @@ package de.voize.reaktnativetoolkit.util
  *
  * Methods of a class implementing this interface are called from the RCViewManager subclass from Objective-C.
  */
-interface ReactNativeIOSViewManager
+interface ReactNativeIOSViewWrapper
+
+/**
+ * A subclass of this interface serves as a factory for creating instances of the [ReactNativeIOSViewWrapper].
+ * Such a factory is needed so the factory is initialized from Kotlin injecting all the necessary dependencies
+ * and then the factory can be used in Objective-C to create instances of the corresponding [ReactNativeIOSViewWrapper].
+ */
+interface ReactNativeIOSViewWrapperFactory

--- a/kotlin/reakt-native-toolkit/src/iosMain/kotlin/de/voize/reaktnativetoolkit/util/ReactNativeViewManagerProvider.kt
+++ b/kotlin/reakt-native-toolkit/src/iosMain/kotlin/de/voize/reaktnativetoolkit/util/ReactNativeViewManagerProvider.kt
@@ -1,9 +1,9 @@
 package de.voize.reaktnativetoolkit.util
 
 actual interface ReactNativeViewManagerProvider {
-    fun getViewManager(): Pair<String, ReactNativeIOSViewManager>
+    fun getViewWrapperFactory(): Pair<String, ReactNativeIOSViewWrapperFactory>
 }
 
-fun List<ReactNativeViewManagerProvider>.getViewManagers(): Map<String, ReactNativeIOSViewManager> {
-    return associate { it.getViewManager() }
+fun List<ReactNativeViewManagerProvider>.getViewWrapperFactories(): Map<String, ReactNativeIOSViewWrapperFactory> {
+    return associate { it.getViewWrapperFactory() }
 }


### PR DESCRIPTION
Currently there is one singleton React Native view manager corresponding to an annotated Composable and this setup is required by React Native. But currently the flows that propagate React Native props to the Composable are defined on this view manager, which does not make sense if you have multiple instances of the view rendered in React Native. Instead the helper structures need to be maintained per instance of the view.

On Android, we fix this by adding a `ComposeViewWrapper` that holds the compose view and the helper structures and is initialized in `createViewInstance` instead of a `ComposeView` directly.

On iOS this is more complicated as the RN view manager is in Obj-C, the view wrapper is in Kotlin and the view instance is created in Obj-C. To have the view wrapper per view we add a factory that creates this class. So the view wrapper and the view can be created together.