### PR TITLE
Remove dependency on shared framework header in generated Obj-C code 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## unreleased
+
+- Update iOS view manager code generation to only require interfaces for view wrapper and view wrapper factory in Obj-C code
+
 ## v0.19.2
 
 - Fix view manager boolean react prop is always true

--- a/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/utils.kt
+++ b/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/utils.kt
@@ -68,4 +68,3 @@ internal fun List<PlatformInfo>.isAndroid(): Boolean {
     val platformNames = this.map { it.platformName }
     return JvmPlatform in platformNames && NativePlatform !in platformNames
 }
-

--- a/kotlin/reakt-native-toolkit/src/iosMain/kotlin/de/voize/reaktnativetoolkit/util/ReactNativeIOSViewWrapper.kt
+++ b/kotlin/reakt-native-toolkit/src/iosMain/kotlin/de/voize/reaktnativetoolkit/util/ReactNativeIOSViewWrapper.kt
@@ -1,5 +1,7 @@
 package de.voize.reaktnativetoolkit.util
 
+import platform.UIKit.UIView
+
 /**
  * A subclass of this interface serves as the communication between an annotated Compose view
  * and its respective RCTViewManager subclass (which is generated into Objective-C code).
@@ -9,11 +11,17 @@ package de.voize.reaktnativetoolkit.util
  *
  * Methods of a class implementing this interface are called from the RCViewManager subclass from Objective-C.
  */
-interface ReactNativeIOSViewWrapper
+interface ReactNativeIOSViewWrapper {
+    fun registerCallback(withName: String, callback: (args: Map<String, Any>) -> Unit)
+    fun setPropValue(withName: String, value: Any)
+    fun view(): UIView
+}
 
 /**
  * A subclass of this interface serves as a factory for creating instances of the [ReactNativeIOSViewWrapper].
  * Such a factory is needed so the factory is initialized from Kotlin injecting all the necessary dependencies
  * and then the factory can be used in Objective-C to create instances of the corresponding [ReactNativeIOSViewWrapper].
  */
-interface ReactNativeIOSViewWrapperFactory
+interface ReactNativeIOSViewWrapperFactory {
+    fun createViewWrapper(): ReactNativeIOSViewWrapper
+}


### PR DESCRIPTION
Currently the generated Obj-C code for the view managers accesses the Kotlin types via the `shared.h` header.

The accessed types are `Shared...RNViewWrapperIOS` and `Shared...RNViewWrapperFactoryIOS` for each respective view manager.

The problems with this are twofold 
1. This makes an assumption about how the Kotlin framework is named, usually `shared`. Although this could be fixed through some configuration.
2. When the RN toolkit is used in a dependency of your app you need to get the generated Obj-C files of that dependency somehow. 
When you do that you now have to export the dependency into the shared framework via `cocoapods { export (...) }` of your app as the header needs to include the types so the Obj-C code can access them. 
Furthermore, this creates the constraint that the shared framework of the app has the same name as the shared framework of the dependency. 

There are multiple ways to solve this:
1. Use reflection and any pointers in the Obj-C code to remove the requirement for the types. This makes the generated Obj-C code quite ugly and not type-safe but as it is generated it is still guaranteed to be correct and not create any runtime issues. 
2. Generate matching interfaces for each `Shared...RNViewWrapperIOS` and `Shared...RNViewWrapperFactoryIOS` directly into the Obj-C code and cast the incoming objects to that interface. This can be a bit tricky as you have to reimplement the Kotlin <> Obj-C interop interface generation to some extent.
3. Drop access to specific `Shared...RNViewWrapperIOS` and `Shared...RNViewWrapperFactoryIOS` types and replace it with an interface that abstracts all view wrappers / view wrapper factories. We already have `ReactNativeIOSViewWrapperFactory` and `ReactNativeIOSViewWrapper` Kotlin interface but currently they are empty and all methods are defined custom on the implementation. For `ReactNativeIOSViewWrapper`, we would need to combine the generated setter methods per prop into one shared prop value setter method with a signature that works for all view wrappers.

We go with option 3. However, it does not solve problem 1. But this could be handled differently.