### PR TITLE
Make compose views transparent on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 - Fix generation for compose views with no props and no callbacks
+- Make compose views transparent on iOS
 
 ## v0.19.3
 

--- a/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MyTransparentComposeView.kt
+++ b/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MyTransparentComposeView.kt
@@ -1,0 +1,24 @@
+package com.myrnproject.shared
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import de.voize.reaktnativetoolkit.annotation.ReactNativeViewManager
+
+@Composable
+@ReactNativeViewManager("MyTransparentComposeView")
+internal fun MyTransparentComposeView() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Color.hsl(0f, 0f, 0f, 0.3f)
+            )
+    ) {
+        Text("Compose overlay", color = Color.White)
+    }
+}

--- a/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/RNViewManagersList.kt
+++ b/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/RNViewManagersList.kt
@@ -9,5 +9,6 @@ fun getReactNativeViewManagerProviders(
         MyComposeViewRNViewManagerProvider(persistentConfig),
         MySecondComposeViewRNViewManagerProvider(),
         MyMinimalComposeViewRNViewManagerProvider(),
+        MyTransparentComposeViewRNViewManagerProvider(),
     )
 }

--- a/example/src/components/NativeView.tsx
+++ b/example/src/components/NativeView.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import {
   MyComposeView,
   MySecondComposeView,
+  MyTransparentComposeView,
 } from '../generated/nativeComponents';
 import { com } from '../generated/models';
 
@@ -59,6 +60,12 @@ const NativeComposeView: React.FC = () => {
           style={styles.nativeListItem}
         />
       ))}
+      <View style={{ borderWidth: 1, width: '100%' }}>
+        <Text style={{ padding: 20 }}>This RN text should be visible</Text>
+        <MyTransparentComposeView
+          style={{ width: '100%', height: '100%', position: 'absolute' }}
+        />
+      </View>
     </View>
   );
 };

--- a/example/src/generated/nativeComponents.tsx
+++ b/example/src/generated/nativeComponents.tsx
@@ -86,6 +86,12 @@ interface MySecondComposeViewProps extends ViewProps {
 
 }
 
+interface NativeMyTransparentComposeViewProps {
+}
+
+interface MyTransparentComposeViewProps extends ViewProps {
+}
+
 const NativeMyComposeView = requireNativeComponent<NativeMyComposeViewProps>("MyComposeView");
 
 export const MyComposeView = (props: MyComposeViewProps) => {
@@ -227,4 +233,13 @@ export const MySecondComposeView = (props: MySecondComposeViewProps) => {
     onPress()}, [onPress]);
   return <NativeMySecondComposeView {...rest} index={indexMemoized}
   onPress={nativeOnPress} />;
+};
+
+const NativeMyTransparentComposeView = requireNativeComponent<NativeMyTransparentComposeViewProps>("MyTransparentComposeView");
+
+export const MyTransparentComposeView = (props: MyTransparentComposeViewProps) => {
+  const {
+  ...rest
+  } = props;
+  return <NativeMyTransparentComposeView {...rest}  />;
 };

--- a/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeViewManagerGenerator.kt
+++ b/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeViewManagerGenerator.kt
@@ -566,6 +566,7 @@ class ReactNativeViewManagerGenerator(
      * ```kotlin
      * package <package of annotated compose function>
      *
+     * import androidx.compose.runtime.ExperimentalComposeApi
      * import androidx.compose.ui.window.ComposeUIViewController
      * import de.voize.reaktnativetoolkit.util.ReactNativeIOSViewWrapper
      * import kotlinx.coroutines.flow.MutableSharedFlow
@@ -589,7 +590,8 @@ class ReactNativeViewManagerGenerator(
      *         }
      *     }
      *
-     *     public fun view(): UIView = ComposeUIViewController {
+     *     @OptIn(ExperimentalComposeApi::class)
+     *     public fun view(): UIView = ComposeUIViewController({ opaque = false }) {
      *         <class name of annotated compose function>(
      *              <prop name> = <prop name>,
      *              <function prop name> = { arg0, arg1 ->
@@ -730,10 +732,15 @@ class ReactNativeViewManagerGenerator(
             addFunction(
                 FunSpec.builder("view")
                     .addModifiers(KModifier.PUBLIC, KModifier.OVERRIDE)
+                    .addAnnotation(
+                        AnnotationSpec.builder(OptInClassName)
+                            .addMember("%T::class", ExperimentalComposeApiClassName)
+                            .build()
+                    )
                     .returns(UIViewClassName)
                     .addStatement(
                         """
-                            return %T {
+                            return %T({ opaque = false }) {
                                 %T(%L)
                             }.view
                             """.trimIndent(),
@@ -1338,3 +1345,5 @@ private val ReactThemedReactContextClassName =
 private val ComposeUIViewControllerClassName = ClassName("androidx.compose.ui.window", "ComposeUIViewController")
 private val UIViewClassName = ClassName("platform.UIKit", "UIView")
 private val NSNumberClassName = ClassName("platform.Foundation", "NSNumber")
+private val ExperimentalComposeApiClassName = ClassName("androidx.compose.runtime", "ExperimentalComposeApi")
+private val OptInClassName = ClassName("kotlin", "OptIn")


### PR DESCRIPTION
Android 

<img width="292" alt="Screenshot 2024-12-05 at 15 44 25" src="https://github.com/user-attachments/assets/f5fb57c2-6967-4fe3-b80f-a322f987acc8">


iOS

![Screenshot 2024-12-05 at 15 46 53](https://github.com/user-attachments/assets/4eab320f-a954-46fb-a0ac-2d5dff2c5b76)

iOS with `ComposeUIViewController({ opaque = false })`

![Screenshot 2024-12-05 at 15 52 51](https://github.com/user-attachments/assets/12233d5c-b2a2-437c-b572-320f079e99cb)

adding `fillMaxSize` modifier (seems to be automatic on Android)

![Screenshot 2024-12-05 at 15 54 09](https://github.com/user-attachments/assets/f7058445-776a-4cfa-b874-921276485dc6)

