### PR TITLE
Compose view props are direct values instead of flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## unreleased
+
+- Update generation for compose views so props are direct values instead of flows
+
 ## v0.19.4
 
 - Fix generation for compose views with no props and no callbacks

--- a/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MyComposeView.kt
+++ b/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MyComposeView.kt
@@ -25,25 +25,25 @@ data class MyDataClass(
 @ReactNativeViewManager("MyComposeView")
 internal fun MyComposeView(
     @ReactNativeProp
-    message: Flow<String>,
+    message: String,
     @ReactNativeProp
-    textFieldValue: Flow<String>,
+    textFieldValue: String,
     @ReactNativeProp
-    nullableStringProp: Flow<String?>,
+    nullableStringProp: String?,
     @ReactNativeProp
-    boolProp: Flow<Boolean>,
+    boolProp: Boolean,
     @ReactNativeProp
-    intProp: Flow<Int>,
+    intProp: Int,
     @ReactNativeProp
-    doubleProp: Flow<Double>,
+    doubleProp: Double,
     @ReactNativeProp
-    floatProp: Flow<Float>,
+    floatProp: Float,
     @ReactNativeProp
-    objectProp: Flow<MyDataClass>,
+    objectProp: MyDataClass,
     @ReactNativeProp
-    enumProp: Flow<Enum>,
+    enumProp: Enum,
     @ReactNativeProp
-    listProp: Flow<List<MyDataClass>>,
+    listProp: List<MyDataClass>,
     @ReactNativeProp
     onTextFieldValueChange: (String) -> Unit,
     @ReactNativeProp
@@ -64,29 +64,20 @@ internal fun MyComposeView(
     persistentConfig: PersistentConfig,
 ) {
     val name by persistentConfig.getConfigAsFlow("name").collectAsState(null)
-    val messageValue by message.collectAsState("initial!")
-    val nullableStringValue by nullableStringProp.collectAsState(null)
-    val boolValue by boolProp.collectAsState(null)
-    val intValue by intProp.collectAsState(null)
-    val doubleValue by doubleProp.collectAsState(null)
-    val floatValue by floatProp.collectAsState(null)
-    val objectValue by objectProp.collectAsState(null)
-    val enumValue by enumProp.collectAsState(null)
-    val listValue by listProp.collectAsState(emptyList())
 
     Column {
         Text("Hello from Compose, ${name ?: "unknown"}!")
 
         listOf(
-            "message" to messageValue,
-            "nullableStringProp" to nullableStringValue,
-            "boolProp" to boolValue,
-            "intProp" to intValue,
-            "doubleProp" to doubleValue,
-            "floatProp" to floatValue,
-            "objectProp" to objectValue,
-            "enumProp" to enumValue,
-            "listProp" to listValue,
+            "message" to message,
+            "nullableStringProp" to nullableStringProp,
+            "boolProp" to boolProp,
+            "intProp" to intProp,
+            "doubleProp" to doubleProp,
+            "floatProp" to floatProp,
+            "objectProp" to objectProp,
+            "enumProp" to enumProp,
+            "listProp" to listProp,
         ).forEach { (propName, propValue) ->
             Text("Value of prop \"$propName\": $propValue")
         }
@@ -122,7 +113,7 @@ internal fun MyComposeView(
             Text("Click me!")
         }
         TextField(
-            value = textFieldValue.collectAsState("").value,
+            value = textFieldValue,
             onValueChange = onTextFieldValueChange,
             label = { Text("This text field is controlled by React Native") },
         )

--- a/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MySecondComposeView.kt
+++ b/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MySecondComposeView.kt
@@ -3,23 +3,18 @@ package com.myrnproject.shared
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import de.voize.reaktnativetoolkit.annotation.ReactNativeProp
 import de.voize.reaktnativetoolkit.annotation.ReactNativeViewManager
-import kotlinx.coroutines.flow.Flow
 
 @Composable
 @ReactNativeViewManager("MySecondComposeView")
 internal fun MySecondComposeView(
     @ReactNativeProp
-    index: Flow<Int>,
+    index: Int,
     @ReactNativeProp
     onPress: () -> Unit,
 ) {
-    val indexValue by index.collectAsState(null)
-
     Button(onClick = onPress) {
-        Text("Compose View Index: $indexValue")
+        Text("Compose View Index: $index")
     }
 }

--- a/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeViewManagerTypescriptGenerator.kt
+++ b/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeViewManagerTypescriptGenerator.kt
@@ -63,7 +63,7 @@ internal class ReactNativeViewManagerTypescriptGenerator(
         val nativePropsInterface = InterfaceSpec.builder(nativePropsInterfaceName).apply {
             rnViewManager.reactNativeProps.map { reactNativeProp ->
                 when (reactNativeProp) {
-                    is ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.FlowProp -> {
+                    is ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.ValueProp -> {
                         addProperty(
                             PropertySpec.builder(
                                 reactNativeProp.name,
@@ -91,7 +91,7 @@ internal class ReactNativeViewManagerTypescriptGenerator(
             addSuperInterface(ViewPropsTypeName)
             rnViewManager.reactNativeProps.map { reactNativeProp ->
                 when (reactNativeProp) {
-                    is ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.FlowProp -> {
+                    is ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.ValueProp -> {
                         addProperty(
                             PropertySpec.builder(
                                 reactNativeProp.name,
@@ -175,7 +175,7 @@ internal class ReactNativeViewManagerTypescriptGenerator(
                                     if (rnViewManager.reactNativeProps.isNotEmpty()) {
                                         rnViewManager.reactNativeProps.joinToString(",\n") {
                                             when (it) {
-                                                is ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.FlowProp -> it.name
+                                                is ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.ValueProp -> it.name
                                                 is ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.FunctionProp -> it.name
                                             }
                                         } + ",\n"
@@ -185,7 +185,7 @@ internal class ReactNativeViewManagerTypescriptGenerator(
                                 )
                             )
 
-                            rnViewManager.reactNativeProps.filterIsInstance<ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.FlowProp>().forEach {
+                            rnViewManager.reactNativeProps.filterIsInstance<ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.ValueProp>().forEach {
                                 val type = it.typeArgument
                                 val value = convertTypeToJson(
                                     it.name.asCodeBlock(),
@@ -269,7 +269,7 @@ internal class ReactNativeViewManagerTypescriptGenerator(
                                     CodeBlock.of("{...%L}", restVarName),
                                     rnViewManager.reactNativeProps.map {
                                         when (it) {
-                                            is ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.FlowProp -> {
+                                            is ReactNativeViewManagerGenerator.RNViewManager.ReactNativeProp.ValueProp -> {
                                                 jsxProp(it.name, CodeBlock.of(it.name.toMemoizedPropName()))
                                             }
 

--- a/kotlin/reakt-native-toolkit/src/commonMain/kotlin/de/voize/reaktnativetoolkit/util/StateOrInitial.kt
+++ b/kotlin/reakt-native-toolkit/src/commonMain/kotlin/de/voize/reaktnativetoolkit/util/StateOrInitial.kt
@@ -1,0 +1,6 @@
+package de.voize.reaktnativetoolkit.util
+
+sealed interface StateOrInitial<out T> {
+    data object Initial : StateOrInitial<Nothing>
+    data class State<T>(val value: T) : StateOrInitial<T>
+}


### PR DESCRIPTION
Updated the generation for Compose views so that @ReactNativeProp annotated value parameters do not have to be flows but can be direct values.

For this I updated that the generated view uses state flows instead of shared flows and that the Composable does not render until all state flows do not have an initial dummy value anymore.

It could have been that this leads to short flicker that the Composable appears after the props state flows are populated but a test where compose where periodically mounted and unmounted along the RN views showed no such flickers.  

Android

https://github.com/user-attachments/assets/e9329df9-9bfa-4428-ac67-f603a85ed13b

iOS

https://github.com/user-attachments/assets/5c871fbc-ddcc-41e2-b734-19fb7ec8b001

