### PR TITLE
Fix crash on iOS with nullable number types in Compose view manager params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## unreleased
+
+- Fix crash on iOS with nullable number types in Compose view manager params
+
 ## v0.21.1
 
 - Fix compiler error for references to external value classes

--- a/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MyComposeView.kt
+++ b/example/android/shared/src/commonMain/kotlin/com/myrnproject/shared/MyComposeView.kt
@@ -33,19 +33,39 @@ internal fun MyComposeView(
     @ReactNativeProp
     boolProp: Boolean,
     @ReactNativeProp
+    nullableBoolProp: Boolean?,
+    @ReactNativeProp
     intProp: Int,
+    @ReactNativeProp
+    nullableIntProp: Int?,
     @ReactNativeProp
     doubleProp: Double,
     @ReactNativeProp
     floatProp: Float,
+    // Nullable Double or Float do not seem to work in the Android RN bridge (but works on iOS)
+    // java.lang.RuntimeException: Unrecognized type: class java.lang.Double for method: com.myrnproject.shared.MyComposeViewRNViewManagerAndroid#setNullableDoubleProp
+    // java.lang.RuntimeException: Unrecognized type: class java.lang.Float for method: com.myrnproject.shared.MyComposeViewRNViewManagerAndroid#setNullableFloatProp
+    //
+    // @ReactNativeProp
+    // nullableDoubleProp: Double?,
+    // @ReactNativeProp
+    // nullableFloatProp: Float?,
     @ReactNativeProp
     objectProp: MyDataClass,
     @ReactNativeProp
+    nullableObjectProp: MyDataClass?,
+    @ReactNativeProp
     enumProp: Enum,
+    @ReactNativeProp
+    nullableEnumProp: Enum?,
     @ReactNativeProp
     listProp: List<MyDataClass>,
     @ReactNativeProp
+    nullableListProp: List<MyDataClass>?,
+    @ReactNativeProp
     sealedInterface: TestSealedInterfaceType,
+    @ReactNativeProp
+    nullableSealedInterface: TestSealedInterfaceType?,
     @ReactNativeProp
     onTextFieldValueChange: (String) -> Unit,
     @ReactNativeProp
@@ -55,13 +75,21 @@ internal fun MyComposeView(
         stringParam: String,
         nullableStringParam: String?,
         boolParam: Boolean,
+        nullableBoolParam: Boolean?,
         intParam: Int,
+        nullableIntParam: Int?,
         doubleParam: Double,
+        nullableDoubleParam: Double?,
         floatParam: Float,
+        nullableFloatParam: Float?,
         objectParam: MyDataClass,
+        nullableObjectParam: MyDataClass?,
         enumParam: Enum,
+        nullableEnumParam: Enum?,
         listParam: List<MyDataClass>,
+        nullableListParam: List<MyDataClass>?,
         sealedInterfaceParam: TestSealedInterfaceType,
+        nullableSealedInterfaceParam: TestSealedInterfaceType?,
     ) -> Unit,
     // dependency injection
     persistentConfig: PersistentConfig,
@@ -75,12 +103,19 @@ internal fun MyComposeView(
             "message" to message,
             "nullableStringProp" to nullableStringProp,
             "boolProp" to boolProp,
+            "nullableBoolProp" to nullableBoolProp,
             "intProp" to intProp,
+            "nullableIntProp" to nullableIntProp,
             "doubleProp" to doubleProp,
             "floatProp" to floatProp,
             "objectProp" to objectProp,
+            "nullableObjectProp" to nullableObjectProp,
             "enumProp" to enumProp,
+            "nullableEnumProp" to nullableEnumProp,
             "listProp" to listProp,
+            "nullableListProp" to nullableListProp,
+            "sealedInterfaceProp" to sealedInterface,
+            "nullableSealedInterfaceProp" to nullableSealedInterface,
         ).forEach { (propName, propValue) ->
             Text("Value of prop \"$propName\": $propValue")
         }
@@ -91,9 +126,13 @@ internal fun MyComposeView(
                 "stringParam",
                 null,
                 true,
+                null,
                 42,
+                null,
                 3.14,
+                null,
                 2.718f,
+                null,
                 MyDataClass(
                     "stringProp",
                     true,
@@ -101,7 +140,9 @@ internal fun MyComposeView(
                     3.14,
                     2.718f,
                 ),
+                null,
                 Enum.Option1,
+                null,
                 listOf(
                     MyDataClass(
                         "stringProp",
@@ -111,7 +152,9 @@ internal fun MyComposeView(
                         2.718f,
                     ),
                 ),
+                null,
                 TestSealedInterfaceType.Option3,
+                null,
             )
         }) {
             Text("Click me!")

--- a/example/ios/MyRNProject/Info.plist
+++ b/example/ios/MyRNProject/Info.plist
@@ -48,5 +48,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1356,57 +1356,57 @@ SPEC CHECKSUMS:
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 6eae7edb2f563ee41d7c1f91f4f2e57c26d8a5c3
   MyAppShared: 44a61bb8c7ff39ba048be095d4d903d5f1299d0f
-  RCT-Folly: 045d6ecaa59d826c5736dfba0b2f4083ff8d79df
+  RCT-Folly: 5f972de9f7d384c7d0e7380dd7da506228e568f5
   RCTDeprecation: 3ca8b6c36bfb302e1895b72cfe7db0de0c92cd47
   RCTRequired: 9fc183af555fd0c89a366c34c1ae70b7e03b1dc5
   RCTTypeSafety: db1dd5ad1081a5e160d30bb29ef922693d5ac4b1
   React: 8650d592d90b99097504b8dcfebab883972aed71
   React-callinvoker: 6bb8b399ab8cec59e52458c3a592aa1fca130b68
-  React-Codegen: 7014b8564cb45f51d01c950256456e20f679d42e
-  React-Core: 119ddf031a18926c2f59849bedcc83c1ba347419
-  React-CoreModules: 087c24b785afc79d29d23bffe7b02f79bb00cf76
-  React-cxxreact: 67a110c97ed6a53b393be3c90fc3f0b482770bd1
+  React-Codegen: 9f2e860b1ac0b9395529c9573a8b07dbc3886a3e
+  React-Core: 70f3fb32d27fe0dd16e5600c9ebbbc861de59192
+  React-CoreModules: c5791800e490979b15b819e13ceaee42aa4a2672
+  React-cxxreact: 666dc368c229154ef3088e86b94b847294cb36ba
   React-debug: 41175f3e30dfa8af6eab2631261e1eac26307f9f
-  React-Fabric: 235d71c7d7973fb5c3f099f2962d6b5362be6107
-  React-FabricImage: 44f4ee8c9331688ab5e907a40cbd49010b05e687
+  React-Fabric: 5127d63a4233207891ea79a6d9f751309319a6f5
+  React-FabricImage: ee08313993abcd1666880113eaa00f728e2620a1
   React-featureflags: 5e7e78c607661fe7f72bc38c6f03736e0876753a
-  React-graphics: 354adf8693bf849e696bf5096abc8cdc22c78ab4
-  React-hermes: 17c369e15cfb535d7bc880d432e0e291c81d10d9
-  React-ImageManager: 74e0898e24b12c45c40019b8558a1310d0b2a47c
-  React-jserrorhandler: 33cb327f5c6e1571b362f1a9c762ff839a5adb15
-  React-jsi: 1e0be0c7526a8fdd3b9e8c086bddcddbad263cd5
-  React-jsiexecutor: 04c1e790290e8cc3cd18e59c9cc5bdd18af325ef
-  React-jsinspector: 5daae7b6729d84bd61026899a6f664bdcff3ac28
-  React-jsitracing: 36a2bbc272300313653d980de5ab700ec86c534a
-  React-logger: 03f2f7b955cfe24593a2b8c9705c23e142d1ad24
-  React-Mapbuffer: 5e05d78fe6505f4a054b86f415733d4ad02dd314
-  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
+  React-graphics: ea6e3c3f77683565552986548ba6a2938cb83251
+  React-hermes: 5f20efa62d7fc7e4df8cdfa5b6c54f43a50f1a51
+  React-ImageManager: 49a461cd14ed15749fe7371afb1924e8a72aecc1
+  React-jserrorhandler: bccc0691bf5195f4da1292a4d2fbaa13fa895f89
+  React-jsi: 7f62c2cecdcf64c9e3e7518a523652433795fed2
+  React-jsiexecutor: 59436ebad9bdc490ba194a3a61f763b32f2e0219
+  React-jsinspector: 76a5c6385781b120f4ff0c09e515fb16528bfc4a
+  React-jsitracing: d30048b056e8c9673dfbe67813bdb874c03558a5
+  React-logger: 5ae0978955199c132e71e8cf7797f619a6d17164
+  React-Mapbuffer: 3b85b3778e447cd1f06d353b8e967af50f272829
+  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
   React-nativeconfig: 951ec32f632e81cbd7d40aebb3211313251c092e
-  React-NativeModulesApple: 0b3a42ca90069119ef79d8b2327d01441d71abd4
+  React-NativeModulesApple: c8963908368d05a75af1eef7451ff86efc9b6517
   React-perflogger: 271f1111779fef70f9502d1d38da5132e5585230
   React-RCTActionSheet: 5d6fb9adb11ab1bfbce6695a2b785767e4658c53
-  React-RCTAnimation: 86ace32c56e69b3822e7e5184ea83a79d47fc7b9
-  React-RCTAppDelegate: 74b45c4e3c1c23db88385d74cf4f5a8500694527
-  React-RCTBlob: fb91c62a549f004e251235c65c665c6890a923a3
-  React-RCTFabric: af6b9bc4aa9dfa0af1a1bcf5d8e5c5b1f17ae99c
-  React-RCTImage: b482f07cfdbe8e413edbf9d85953cecdb569472c
-  React-RCTLinking: fbd73a66cab34df69b2389c17f200e4722890fd9
-  React-RCTNetwork: fbdd716fbd6e53feb6d8e00eeb85e8184ad42ac8
-  React-RCTSettings: 11c3051b965593988298a3f5fb39e23bf6f7df9f
-  React-RCTText: f240b4d39c36c295204d29e7634a2fac450b6d29
-  React-RCTVibration: 1750f80b39e1ad9b4f509f4fdf19a803f7ab0d38
-  React-rendererdebug: a89ffa25c7670de8f22e0b322dfdd8333bc0d126
+  React-RCTAnimation: 0d11291f869c8a15cff4fd21dca031a83f9e8527
+  React-RCTAppDelegate: 5194e63613db66d448dfae9f98b269bf6291915c
+  React-RCTBlob: 1689488d4a465692d29b783c8e310a45bf9c1c96
+  React-RCTFabric: 5b018dc56bfedce0121992ddc44a46419a787778
+  React-RCTImage: 80ba9b23ecf87536b14c5eb38bd76f9d2b842c8a
+  React-RCTLinking: afd22b0854eba28eb277baad45c37ada5ef77bc3
+  React-RCTNetwork: ffe5a1021f5a0bcbdf7944665dc44856493ab5bd
+  React-RCTSettings: f8472ee7998de8d186c198e820c40fcaf9ce4571
+  React-RCTText: f556484bf1ba49a7c9b1ce1138608657d80e0bcb
+  React-RCTVibration: 236755b4231073ebac6cabc3864edb4cd6308d89
+  React-rendererdebug: c1dac9f04b12f05929b6113a50aec5fcd5132b94
   React-rncore: a3ab9e7271a5c692918e2a483beb900ff0a51169
-  React-RuntimeApple: cdc563e811785f675925032d3bc4092a2aaa0b82
-  React-RuntimeCore: f4af3a86a6a69d31721067f17196a582da25d2fc
+  React-RuntimeApple: a095023ded63a404c31732859b0732a545083273
+  React-RuntimeCore: 4580bf6bc6a5c2d9c04995b4ded51751901894ff
   React-runtimeexecutor: 4471221991b6e518466a0422fbeb2158c07c36e1
-  React-RuntimeHermes: 3d9f53ac3330bb71d42f2acb9a3061a0b992be5c
-  React-runtimescheduler: 7fe561d179b97cecd0c2bec0bbd08f9fd8581c26
-  React-utils: f013537c3371270d2095bff1d594d00d4bc9261b
-  ReactCommon: 2cde697fd80bd31da1d6448d25a5803088585219
+  React-RuntimeHermes: 48b3c464990052c75a5ca0a385f1de8b2041a5e1
+  React-runtimescheduler: 5ae8dc5d3195a1582ad076493ab6d9d3fd7c1287
+  React-utils: c2c26076afce4fcf8d3d81dd75f8099a5a988383
+  ReactCommon: b1dfa365018c636c73437981ee235c1a35f0e34f
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 56f906bf6c11c931588191dde1229fd3e4e3d557
 
 PODFILE CHECKSUM: 8d61ee68d99f8c99309e09eb992b0432354030cf
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/src/components/NativeView.tsx
+++ b/example/src/components/NativeView.tsx
@@ -18,11 +18,16 @@ const NativeComposeView: React.FC = () => {
         <MyComposeView
           style={styles.nativeView}
           message="Hello from React Native!"
+          textFieldValue={text}
           nullableStringProp={null}
           boolProp={true}
+          nullableBoolProp={null}
           intProp={42}
-          floatProp={42.42}
+          nullableIntProp={null}
           doubleProp={42.42}
+          // nullableDoubleProp={null}
+          floatProp={42.42}
+          // nullableFloatProp={null}
           objectProp={{
             stringProp: 'hello',
             boolProp: true,
@@ -30,6 +35,7 @@ const NativeComposeView: React.FC = () => {
             floatProp: 42.42,
             doubleProp: 42.42,
           }}
+          nullableObjectProp={null}
           listProp={[
             {
               stringProp: 'hello',
@@ -39,11 +45,13 @@ const NativeComposeView: React.FC = () => {
               doubleProp: 42.42,
             },
           ]}
+          nullableListProp={null}
           enumProp={com.myrnproject.shared.Enum.Option1}
-          textFieldValue={text}
+          nullableEnumProp={null}
           sealedInterface={{
             type: com.myrnproject.shared.TestSealedInterfaceTypeType.Option3,
           }}
+          nullableSealedInterface={null}
           onTextFieldValueChange={setText}
           onButtonPress={() => setCounter((prev) => prev + 1)}
           onTestParams={(...args) => {
@@ -94,7 +102,7 @@ const styles = StyleSheet.create({
   },
   nativeView: {
     width: '100%',
-    height: 400,
+    height: 600,
   },
   nativeListItem: {
     width: '100%',

--- a/example/src/generated/nativeComponents.tsx
+++ b/example/src/generated/nativeComponents.tsx
@@ -14,7 +14,11 @@ interface NativeMyComposeViewProps {
 
   boolProp: boolean;
 
+  nullableBoolProp: boolean | null;
+
   intProp: number;
+
+  nullableIntProp: number | null;
 
   doubleProp: number;
 
@@ -22,11 +26,19 @@ interface NativeMyComposeViewProps {
 
   objectProp: string;
 
+  nullableObjectProp: string;
+
   enumProp: string;
+
+  nullableEnumProp: string;
 
   listProp: string;
 
+  nullableListProp: string;
+
   sealedInterface: string;
+
+  nullableSealedInterface: string;
 
   onTextFieldValueChange: (event: any) => void;
 
@@ -46,7 +58,11 @@ interface MyComposeViewProps extends ViewProps {
 
   boolProp: boolean;
 
+  nullableBoolProp: boolean | null;
+
   intProp: number;
+
+  nullableIntProp: number | null;
 
   doubleProp: number;
 
@@ -54,17 +70,25 @@ interface MyComposeViewProps extends ViewProps {
 
   objectProp: com.myrnproject.shared.MyDataClass;
 
+  nullableObjectProp: com.myrnproject.shared.MyDataClass | null;
+
   enumProp: com.myrnproject.shared.Enum;
+
+  nullableEnumProp: com.myrnproject.shared.Enum | null;
 
   listProp: Array<com.myrnproject.shared.MyDataClass>;
 
+  nullableListProp: Array<com.myrnproject.shared.MyDataClass> | null;
+
   sealedInterface: com.myrnproject.shared.TestSealedInterfaceType;
+
+  nullableSealedInterface: com.myrnproject.shared.TestSealedInterfaceType | null;
 
   onTextFieldValueChange: (arg0: string) => void;
 
   onButtonPress: () => void;
 
-  onTestParams: (arg0: string, arg1: string | null, arg2: boolean, arg3: number, arg4: number, arg5: number, arg6: com.myrnproject.shared.MyDataClass, arg7: com.myrnproject.shared.Enum, arg8: Array<com.myrnproject.shared.MyDataClass>, arg9: com.myrnproject.shared.TestSealedInterfaceType) => void;
+  onTestParams: (arg0: string, arg1: string | null, arg2: boolean, arg3: boolean | null, arg4: number, arg5: number | null, arg6: number, arg7: number | null, arg8: number, arg9: number | null, arg10: com.myrnproject.shared.MyDataClass, arg11: com.myrnproject.shared.MyDataClass | null, arg12: com.myrnproject.shared.Enum, arg13: com.myrnproject.shared.Enum | null, arg14: Array<com.myrnproject.shared.MyDataClass>, arg15: Array<com.myrnproject.shared.MyDataClass> | null, arg16: com.myrnproject.shared.TestSealedInterfaceType, arg17: com.myrnproject.shared.TestSealedInterfaceType | null) => void;
 
 }
 
@@ -104,13 +128,19 @@ export const MyComposeView = (props: MyComposeViewProps) => {
   textFieldValue,
   nullableStringProp,
   boolProp,
+  nullableBoolProp,
   intProp,
+  nullableIntProp,
   doubleProp,
   floatProp,
   objectProp,
+  nullableObjectProp,
   enumProp,
+  nullableEnumProp,
   listProp,
+  nullableListProp,
   sealedInterface,
+  nullableSealedInterface,
   onTextFieldValueChange,
   onButtonPress,
   onTestParams,
@@ -132,10 +162,18 @@ export const MyComposeView = (props: MyComposeViewProps) => {
     const temp = boolProp;
     return temp;
   })(), [boolProp]);
+  const nullableBoolPropMemoized = useMemo(() => (() => {
+    const temp = nullableBoolProp;
+    return temp === null ? null : (temp);
+  })(), [nullableBoolProp]);
   const intPropMemoized = useMemo(() => (() => {
     const temp = intProp;
     return temp;
   })(), [intProp]);
+  const nullableIntPropMemoized = useMemo(() => (() => {
+    const temp = nullableIntProp;
+    return temp === null ? null : (temp);
+  })(), [nullableIntProp]);
   const doublePropMemoized = useMemo(() => (() => {
     const temp = doubleProp;
     return temp;
@@ -148,10 +186,18 @@ export const MyComposeView = (props: MyComposeViewProps) => {
     const temp = objectProp;
     return com.myrnproject.shared.toJsonMyDataClass(temp);
   })()), [objectProp]);
+  const nullableObjectPropMemoized = useMemo(() => JSON.stringify((() => {
+    const temp = nullableObjectProp;
+    return temp === null ? null : (com.myrnproject.shared.toJsonMyDataClass(temp));
+  })()), [nullableObjectProp]);
   const enumPropMemoized = useMemo(() => JSON.stringify((() => {
     const temp = enumProp;
     return com.myrnproject.shared.toJsonEnum(temp);
   })()), [enumProp]);
+  const nullableEnumPropMemoized = useMemo(() => JSON.stringify((() => {
+    const temp = nullableEnumProp;
+    return temp === null ? null : (com.myrnproject.shared.toJsonEnum(temp));
+  })()), [nullableEnumProp]);
   const listPropMemoized = useMemo(() => JSON.stringify((() => {
     const temp = listProp;
     return temp.map((it: any) => (() => {
@@ -159,10 +205,21 @@ export const MyComposeView = (props: MyComposeViewProps) => {
       return com.myrnproject.shared.toJsonMyDataClass(temp_);
     })());
   })()), [listProp]);
+  const nullableListPropMemoized = useMemo(() => JSON.stringify((() => {
+    const temp = nullableListProp;
+    return temp === null ? null : (temp.map((it: any) => (() => {
+      const temp_ = it;
+      return com.myrnproject.shared.toJsonMyDataClass(temp_);
+    })()));
+  })()), [nullableListProp]);
   const sealedInterfaceMemoized = useMemo(() => JSON.stringify((() => {
     const temp = sealedInterface;
     return com.myrnproject.shared.toJsonTestSealedInterfaceType(temp);
   })()), [sealedInterface]);
+  const nullableSealedInterfaceMemoized = useMemo(() => JSON.stringify((() => {
+    const temp = nullableSealedInterface;
+    return temp === null ? null : (com.myrnproject.shared.toJsonTestSealedInterfaceType(temp));
+  })()), [nullableSealedInterface]);
   const nativeOnTextFieldValueChange = useCallback((event: any) => {
     onTextFieldValueChange(((() => {
       const temp = event.nativeEvent.args[0];
@@ -182,40 +239,73 @@ export const MyComposeView = (props: MyComposeViewProps) => {
       return temp;
     })()) as boolean, ((() => {
       const temp = event.nativeEvent.args[3];
-      return temp;
-    })()) as number, ((() => {
+      return temp === null ? null : (temp);
+    })()) as boolean | null, ((() => {
       const temp = event.nativeEvent.args[4];
       return temp;
     })()) as number, ((() => {
       const temp = event.nativeEvent.args[5];
+      return temp === null ? null : (temp);
+    })()) as number | null, ((() => {
+      const temp = event.nativeEvent.args[6];
       return temp;
     })()) as number, ((() => {
-      const temp = JSON.parse(event.nativeEvent.args[6]);
+      const temp = event.nativeEvent.args[7];
+      return temp === null ? null : (temp);
+    })()) as number | null, ((() => {
+      const temp = event.nativeEvent.args[8];
+      return temp;
+    })()) as number, ((() => {
+      const temp = event.nativeEvent.args[9];
+      return temp === null ? null : (temp);
+    })()) as number | null, ((() => {
+      const temp = JSON.parse(event.nativeEvent.args[10]);
       return com.myrnproject.shared.fromJsonMyDataClass(temp);
     })()) as com.myrnproject.shared.MyDataClass, ((() => {
-      const temp = JSON.parse(event.nativeEvent.args[7]);
+      const temp = JSON.parse(event.nativeEvent.args[11]);
+      return temp === null ? null : (com.myrnproject.shared.fromJsonMyDataClass(temp));
+    })()) as com.myrnproject.shared.MyDataClass | null, ((() => {
+      const temp = JSON.parse(event.nativeEvent.args[12]);
       return com.myrnproject.shared.fromJsonEnum(temp);
     })()) as com.myrnproject.shared.Enum, ((() => {
-      const temp = JSON.parse(event.nativeEvent.args[8]);
+      const temp = JSON.parse(event.nativeEvent.args[13]);
+      return temp === null ? null : (com.myrnproject.shared.fromJsonEnum(temp));
+    })()) as com.myrnproject.shared.Enum | null, ((() => {
+      const temp = JSON.parse(event.nativeEvent.args[14]);
       return temp.map((it: any) => ((() => {
         const temp_ = it;
         return com.myrnproject.shared.fromJsonMyDataClass(temp_);
       })()) as com.myrnproject.shared.MyDataClass);
     })()) as Array<com.myrnproject.shared.MyDataClass>, ((() => {
-      const temp = JSON.parse(event.nativeEvent.args[9]);
+      const temp = JSON.parse(event.nativeEvent.args[15]);
+      return temp === null ? null : (temp.map((it: any) => ((() => {
+        const temp_ = it;
+        return com.myrnproject.shared.fromJsonMyDataClass(temp_);
+      })()) as com.myrnproject.shared.MyDataClass));
+    })()) as Array<com.myrnproject.shared.MyDataClass> | null, ((() => {
+      const temp = JSON.parse(event.nativeEvent.args[16]);
       return com.myrnproject.shared.fromJsonTestSealedInterfaceType(temp);
-    })()) as com.myrnproject.shared.TestSealedInterfaceType)}, [onTestParams]);
+    })()) as com.myrnproject.shared.TestSealedInterfaceType, ((() => {
+      const temp = JSON.parse(event.nativeEvent.args[17]);
+      return temp === null ? null : (com.myrnproject.shared.fromJsonTestSealedInterfaceType(temp));
+    })()) as com.myrnproject.shared.TestSealedInterfaceType | null)}, [onTestParams]);
   return <NativeMyComposeView {...rest} message={messageMemoized}
   textFieldValue={textFieldValueMemoized}
   nullableStringProp={nullableStringPropMemoized}
   boolProp={boolPropMemoized}
+  nullableBoolProp={nullableBoolPropMemoized}
   intProp={intPropMemoized}
+  nullableIntProp={nullableIntPropMemoized}
   doubleProp={doublePropMemoized}
   floatProp={floatPropMemoized}
   objectProp={objectPropMemoized}
+  nullableObjectProp={nullableObjectPropMemoized}
   enumProp={enumPropMemoized}
+  nullableEnumProp={nullableEnumPropMemoized}
   listProp={listPropMemoized}
+  nullableListProp={nullableListPropMemoized}
   sealedInterface={sealedInterfaceMemoized}
+  nullableSealedInterface={nullableSealedInterfaceMemoized}
   onTextFieldValueChange={nativeOnTextFieldValueChange}
   onButtonPress={nativeOnButtonPress}
   onTestParams={nativeOnTestParams} />;

--- a/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeViewManagerGenerator.kt
+++ b/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeViewManagerGenerator.kt
@@ -740,10 +740,30 @@ class ReactNativeViewManagerGenerator(
                                                 decodeFromString(CodeBlock.of("%N as String", valueVarName))
                                             } else {
                                                 when (prop.typeArgument.declaration.qualifiedName?.asString()) {
-                                                    "kotlin.Int" -> CodeBlock.of("(%N as %T).intValue", valueVarName, NSNumberClassName)
-                                                    "kotlin.Double" -> CodeBlock.of("(%N as %T).doubleValue", valueVarName, NSNumberClassName)
-                                                    "kotlin.Float" -> CodeBlock.of("(%N as %T).floatValue", valueVarName, NSNumberClassName)
-                                                    "kotlin.Boolean" -> CodeBlock.of("(%N as %T).boolValue", valueVarName, NSNumberClassName)
+                                                    "kotlin.Int" -> CodeBlock.of(
+                                                        "(%N as %T)%L.intValue",
+                                                        valueVarName,
+                                                        NSNumberClassName.copy(nullable = prop.typeArgument.isMarkedNullable),
+                                                        if (prop.typeArgument.isMarkedNullable) "?" else "",
+                                                    )
+                                                    "kotlin.Double" -> CodeBlock.of(
+                                                        "(%N as %T)%L.doubleValue",
+                                                        valueVarName,
+                                                        NSNumberClassName.copy(nullable = prop.typeArgument.isMarkedNullable),
+                                                        if (prop.typeArgument.isMarkedNullable) "?" else "",
+                                                    )
+                                                    "kotlin.Float" -> CodeBlock.of(
+                                                        "(%N as %T)%L.floatValue",
+                                                        valueVarName,
+                                                        NSNumberClassName.copy(nullable = prop.typeArgument.isMarkedNullable),
+                                                        if (prop.typeArgument.isMarkedNullable) "?" else "",
+                                                    )
+                                                    "kotlin.Boolean" -> CodeBlock.of(
+                                                        "(%N as %T)%L.boolValue",
+                                                        valueVarName,
+                                                        NSNumberClassName.copy(nullable = prop.typeArgument.isMarkedNullable),
+                                                        if (prop.typeArgument.isMarkedNullable) "?" else "",
+                                                    )
                                                     else -> CodeBlock.of("%N as %T", valueVarName, prop.typeArgument.toTypeName())
                                                 }
                                             }


### PR DESCRIPTION
Generated iOS code now looks like this:

```kotlin
override fun setPropValue(withName: String, `value`: Any) {
    when (withName) {
        "nullableBoolProp" -> nullableBoolProp.value = StateOrInitial.State((`value` as NSNumber?)?.boolValue)  
        "nullableIntProp" -> nullableIntProp.value = StateOrInitial.State((`value` as NSNumber?)?.intValue)
```

instead of 

```kotlin
override fun setPropValue(withName: String, `value`: Any) {
    when (withName) {
        "nullableBoolProp" -> nullableBoolProp.value = StateOrInitial.State((`value` as NSNumber).boolValue)  
        "nullableIntProp" -> nullableIntProp.value = StateOrInitial.State((`value` as NSNumber).intValue)
```