### PR TITLE
Support CMP 1.8.x

### DIFF
--- a/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeViewManagerGenerator.kt
+++ b/kotlin/reakt-native-toolkit-ksp/src/main/kotlin/de/voize/reaktnativetoolkit/ksp/processor/ReactNativeViewManagerGenerator.kt
@@ -812,6 +812,7 @@ class ReactNativeViewManagerGenerator(
                     .addAnnotation(
                         AnnotationSpec.builder(OptInClassName)
                             .addMember("%T::class", ExperimentalComposeApiClassName)
+                            .addMember("%T::class", ExperimentalComposeUiApiClassName)
                             .build()
                     )
                     .returns(UIViewClassName)
@@ -1453,4 +1454,5 @@ private val ComposeUIViewControllerClassName = ClassName("androidx.compose.ui.wi
 private val UIViewClassName = ClassName("platform.UIKit", "UIView")
 private val NSNumberClassName = ClassName("platform.Foundation", "NSNumber")
 private val ExperimentalComposeApiClassName = ClassName("androidx.compose.runtime", "ExperimentalComposeApi")
+private val ExperimentalComposeUiApiClassName = ClassName("androidx.compose.ui", "ExperimentalComposeUiApi")
 private val OptInClassName = ClassName("kotlin", "OptIn")


### PR DESCRIPTION
Since compose multplatform 1.8.0, using a non-opaque siwftui viewcontroller needs an additional opt-in flag. 
The annotation exists since cmp 1.6.0, so we don't need to check for the symbol to be resolvable