### PR TITLE
Support explicit JsType annotations field or class

### DIFF
--- a/kotlin/reakt-native-toolkit/src/commonMain/kotlin/de/voize/reaktnativetoolkit/annotation/JSType.kt
+++ b/kotlin/reakt-native-toolkit/src/commonMain/kotlin/de/voize/reaktnativetoolkit/annotation/JSType.kt
@@ -1,5 +1,5 @@
 package de.voize.reaktnativetoolkit.annotation
 
 @Retention(AnnotationRetention.SOURCE)
-@Target(AnnotationTarget.TYPE)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
 annotation class JSType(val identifier: String)


### PR DESCRIPTION
Support @JsType annotations at field or class level which allow users to specify any type for that field or class. This is useful when a type is serialized in a non-standard way and the user wants to use a different TypeScript mapping than the one inferred by the class structure.

This PR is draft until approved in principal by @Legion2 or @erksch . Once approved, I will add docs to the README and add tests.

Resolves #101 